### PR TITLE
feat: Begin implementation of a timed game loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y tini gcc g++ make gnucobol && rm -rf /v
 COPY Makefile .
 COPY main.cob .
 COPY src ./src
+COPY cpp ./cpp
 COPY CBL_GC_SOCKET ./CBL_GC_SOCKET
 COPY blobs ./blobs
 
@@ -15,7 +16,7 @@ COPY blobs ./blobs
 RUN make
 
 # Include runtime dependencies
-ENV COB_PRE_LOAD=CBL_GC_SOCKET:CBL_GC_SOCKET/CBL_GC_SOCKET.so
+ENV COB_PRE_LOAD=CBL_GC_SOCKET:COBOLCRAFT_UTIL
 
 # Run the server within Tini (to handle signals properly)
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,27 @@
 # Compiler
 COBC = cobc
 
-LIB = CBL_GC_SOCKET/CBL_GC_SOCKET.so
+SOCKET_LIB = CBL_GC_SOCKET.so
+UTIL_LIB = COBOLCRAFT_UTIL.so
 SRC = main.cob src/*.cob src/*/*.cob
 BIN = cobolcraft
 
 all: $(BIN)
 
-$(LIB):
+$(SOCKET_LIB):
 	cd CBL_GC_SOCKET && ./build.sh
+	mv CBL_GC_SOCKET/CBL_GC_SOCKET.so .
 
-$(BIN): $(LIB) $(SRC)
+$(UTIL_LIB): cpp/cobolcraft_util.cpp
+	g++ -shared -Wall -O2 -fPIC -o $@ $<
+
+$(BIN): $(SOCKET_LIB) $(UTIL_LIB) $(SRC)
 	$(COBC) -x -debug -Wall -fnotrunc --free -lstdc++ -o $@ $(SRC)
 
 clean:
 	rm -f $(BIN)
-	rm -f $(LIB)
+	rm -f $(SOCKET_LIB)
+	rm -f $(UTIL_LIB)
 
 run: $(BIN)
-	COB_PRE_LOAD=CBL_GC_SOCKET:CBL_GC_SOCKET/CBL_GC_SOCKET.so ./$(BIN)
+	COB_PRE_LOAD=CBL_GC_SOCKET:COBOLCRAFT_UTIL ./$(BIN)

--- a/cpp/cobolcraft_util.cpp
+++ b/cpp/cobolcraft_util.cpp
@@ -1,0 +1,59 @@
+#include "cobolcraft_util.h"
+#include <chrono>
+#include <cstring>
+#include <cstdio>
+
+#define ERRNO_PARAMS 99
+
+static unsigned int convert_cob_uint(char *p, unsigned int len)
+{
+    unsigned int result = 0;
+    for (unsigned int i = 0; i < len; ++i)
+    {
+        // just ignore non-numeric characters for simplicity
+        if (p[i] < '0' || p[i] > '9')
+        {
+            continue;
+        }
+        result = result * 10 + (p[i] - '0');
+    }
+    return result;
+}
+
+static int system_time_millis(char *p1)
+{
+    if (!p1)
+    {
+        return ERRNO_PARAMS;
+    }
+
+    // get current time in milliseconds
+    auto time = std::chrono::system_clock::now().time_since_epoch();
+    long long millis = std::chrono::duration_cast<std::chrono::milliseconds>(time).count();
+
+    // convert to string
+    char buffer[16];
+    snprintf(buffer, 16, "%.15lld", millis);
+    memcpy(p1, buffer, 15);
+
+    return 0;
+}
+
+extern "C" int COBOLCRAFT_UTIL(char *p_code, char *p1)
+{
+    if (!p_code)
+    {
+        return ERRNO_PARAMS;
+    }
+
+    unsigned int code = convert_cob_uint(p_code, 2);
+    switch (code)
+    {
+    // System time in milliseconds.
+    // p1: X(15) - output
+    case 0:
+        return system_time_millis(p1);
+    }
+
+    return ERRNO_PARAMS;
+}

--- a/cpp/cobolcraft_util.h
+++ b/cpp/cobolcraft_util.h
@@ -1,0 +1,1 @@
+extern "C" int COBOLCRAFT_UTIL(char *p_code, char *p1);

--- a/src/util.cob
+++ b/src/util.cob
@@ -1,0 +1,23 @@
+*> --- Util-SystemTimeMillis ---
+*> Calls the function "00" of CobolCraft's utility module written in C++.
+*> This retrieves the current system time in milliseconds.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. Util-SystemTimeMillis.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 BUFFER           PIC X(15).
+    01 ERRNO            PIC 9(3).
+LINKAGE SECTION.
+    01 LK-INT64         PIC 9(20).
+
+PROCEDURE DIVISION USING LK-INT64.
+    CALL "COBOLCRAFT_UTIL" USING "00" BUFFER GIVING ERRNO
+    IF ERRNO NOT = 0 THEN
+        MOVE 0 TO LK-INT64
+        GOBACK
+    END-IF
+    MOVE BUFFER TO LK-INT64
+    GOBACK.
+
+END PROGRAM Util-SystemTimeMillis.


### PR DESCRIPTION
Before this patch, receiving packets from the client was a blocking operation, and it was impossible to do basically anything else at all. Now, each socket read only gets a very short timeout, so no matter how much data could be read, the call will complete - and we will be able to perform other stuff before trying to read again.

Also in this patch, a custom C++ util module is added that has one function implemented to retrieve the system time in milliseconds. Using this, the game update + socket read loop can be timed precisely enough to achieve Minecraft's 20 ticks per second. The idea is to first perform any game logic, then spend the rest of the tick doing socket communication.

Since the read is now (somewhat) async, it should be possible to extend this for multiplayer as well (later).