### PR TITLE
fix: Fix improper `snprintf` call in CBL_GC_SOCKET

### DIFF
--- a/CBL_GC_SOCKET/cob_socket.cpp
+++ b/CBL_GC_SOCKET/cob_socket.cpp
@@ -936,7 +936,7 @@ int _cobsocket_readn(char* p_socket, char* p_bytes, char* p_data, unsigned int p
 
 	// store the number of bytes we have read into buffer
 	//
-	snprintf(l_buf,5,"%.5d",l_bytes);
+	snprintf(l_buf,6,"%.5d",l_bytes);
 	memcpy(p_bytes,l_buf,5);
 
 	return l_ret;

--- a/README.md
+++ b/README.md
@@ -67,5 +67,7 @@ See LICENSE for further information.
 
 This project includes the 3rd-party CBL_GC_SOCKET shared library, licensed under the LGPL v3.
 See CBL_GC_SOCKET/COPYING.lesser for further information.
+Note that line 939 of `CBL_GC_SOCKET/cob_socket.cpp` has been modified (compared to the original distribution of that
+library) to fix improper `snprintf` usage.
 
 "Minecraft" is a trademark of Mojang Synergies AB.


### PR DESCRIPTION
This patch fixes a bug in the CBL_GC_SOCKET library. The snprintf call requires the second parameter to be the size of the buffer including the null terminator. The buffer size is 6, not 5.