### PR TITLE
feat: Store chunk data in RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following features are already working:
 - [X] respond to ping (i.e., show as online in the server list)
 - [X] whitelist (single player, edit `server.cob` to enable/set username)
 - [X] player login
-- [X] sending chunk data to client (very basic)
+- [X] sending chunk data to client
 - [X] player movement
 - [ ] block placement
 - [ ] chat


### PR DESCRIPTION
When the server is starting, it now generates initial world data that is stored in RAM. When a player logs in, the chunks are encoded dynamically and sent to the player. This is half of what is needed for block placement/destruction to be effective - the other half is actually handling the place/destroy packets sent by the client and updating the data in RAM.

For now, a fixed 7x7 chunks are generated, since the performance is not yet optimized for more, and the network usage is quite high.