### PR TITLE
feat: Add initial implementation for placing blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following features are already working:
 - [X] sending chunk data to client
 - [X] player movement
 - [X] player inventory (limited to creative mode)
-- [ ] breaking and placing blocks (still missing block placement; breaking works)
+- [X] breaking and placing blocks (breaking works; placing supports only stone and grass, for now)
 - [ ] chat
 - [ ] multiplayer
 - [ ] persisting data across restarts


### PR DESCRIPTION
This patch adds a very limited first implementation for placing blocks. Due to having no registry data available yet, the item-to-block mapping has to be hardcoded. This means that for now, only two block types can actually be placed.