### PR TITLE
chore: Enable Docker to cache the data extraction layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,16 @@ RUN apt-get update && \
     apt-get install -y gcc g++ make gnucobol curl default-jre-headless && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy source files
+# Perform data extraction first to allow Docker to cache this layer
 COPY Makefile .
+RUN make data
+
+# Copy source files and build
 COPY main.cob .
 COPY src ./src
 COPY cpp ./cpp
 COPY CBL_GC_SOCKET ./CBL_GC_SOCKET
 COPY blobs ./blobs
-
-# Build
 RUN make
 
 # --- Runtime stage ---

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ JSON_DATA = data/generated/reports/registries.json data/generated/reports/blocks
 TEST_SRC = test.cob tests/*.cob
 TEST_BIN = test
 
-all: $(BIN) $(JSON_DATA)
+all: $(BIN) data
+
+data: $(JSON_DATA)
 
 $(SOCKET_LIB):
 	cd CBL_GC_SOCKET && ./build.sh


### PR DESCRIPTION
This patch avoids downloading the Minecraft server .jar and extracting the JSON data from it each time the image is built, even when only the source files changed. This should speed up builds in CI and reduce load on the provider hosting the .jar file.