### PR TITLE
refactor: Use hexadecimal literals for packet IDs

### DIFF
--- a/src/packets/ack-block-change.cob
+++ b/src/packets/ack-block-change.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-AckBlockChange.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 5.
+    01 PACKET-ID        BINARY-LONG             VALUE H'05'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(8).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/add-player.cob
+++ b/src/packets/add-player.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-AddPlayer.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 60.
+    01 PACKET-ID        BINARY-LONG             VALUE H'3C'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(1024).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/block-update.cob
+++ b/src/packets/block-update.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-BlockUpdate.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 9.
+    01 PACKET-ID        BINARY-LONG             VALUE H'09'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(64000).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/chunkdata.cob
+++ b/src/packets/chunkdata.cob
@@ -4,7 +4,7 @@ PROGRAM-ID. SendPacket-ChunkData.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 37.
+    01 PACKET-ID        BINARY-LONG             VALUE H'25'.
     *> constants
     01 ALL-0-BITS       PIC X(8)                VALUE X"0000000000000000".
     01 EMPTY-COMP       PIC X(2)                VALUE X"0a00".

--- a/src/packets/entity-animation.cob
+++ b/src/packets/entity-animation.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-EntityAnimation.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 3.
+    01 PACKET-ID        BINARY-LONG             VALUE H'03'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(8).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/feature-flags.cob
+++ b/src/packets/feature-flags.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-FeatureFlags.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 8.
+    01 PACKET-ID        BINARY-LONG             VALUE H'08'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(64000).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/keepalive.cob
+++ b/src/packets/keepalive.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-KeepAlive.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID    BINARY-LONG             VALUE 36.
+    01 PACKET-ID    BINARY-LONG             VALUE H'24'.
     *> buffer used to store the packet data
     01 PAYLOAD      PIC X(8).
     01 PAYLOADLEN   BINARY-LONG UNSIGNED    VALUE 8.

--- a/src/packets/login-disconnect.cob
+++ b/src/packets/login-disconnect.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-LoginDisconnect.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID    BINARY-LONG             VALUE 0.
+    01 PACKET-ID    BINARY-LONG             VALUE H'00'.
     *> buffer used to store the JSON string
     01 JSONBUFFER   PIC X(64000).
     01 JSONPOS      BINARY-LONG UNSIGNED.

--- a/src/packets/login-play.cob
+++ b/src/packets/login-play.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-LoginPlay.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 41.
+    01 PACKET-ID        BINARY-LONG             VALUE H'29'.
     *> temporary data used during encoding
     01 INT32            BINARY-LONG.
     01 BUFFER           PIC X(64).

--- a/src/packets/login-success.cob
+++ b/src/packets/login-success.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-LoginSuccess.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 2.
+    01 PACKET-ID        BINARY-LONG             VALUE H'02'.
     *> temporary data used during encoding
     01 BUFFER           PIC X(64).
     01 BUFFERLEN        BINARY-LONG UNSIGNED.

--- a/src/packets/player-chat.cob
+++ b/src/packets/player-chat.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-PlayerChat.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 55.
+    01 PACKET-ID        BINARY-LONG             VALUE H'37'.
     *> temporary data used during encoding
     01 UINT16           BINARY-SHORT UNSIGNED.
     01 INT32            BINARY-LONG.

--- a/src/packets/remove-entity.cob
+++ b/src/packets/remove-entity.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-RemoveEntity.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 64.
+    01 PACKET-ID        BINARY-LONG             VALUE H'40'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(1024).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/remove-player.cob
+++ b/src/packets/remove-player.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-RemovePlayer.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 59.
+    01 PACKET-ID        BINARY-LONG             VALUE H'3B'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(1024).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/set-center-chunk.cob
+++ b/src/packets/set-center-chunk.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-SetCenterChunk.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 82.
+    01 PACKET-ID        BINARY-LONG             VALUE H'52'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(16).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/set-container-content.cob
+++ b/src/packets/set-container-content.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-SetContainerContent.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID    BINARY-LONG             VALUE 19.
+    01 PACKET-ID    BINARY-LONG             VALUE H'13'.
     *> buffer used to store the packet data
     01 PAYLOAD      PIC X(64000).
     01 PAYLOADLEN   BINARY-LONG UNSIGNED.

--- a/src/packets/set-equipment.cob
+++ b/src/packets/set-equipment.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-SetEquipment.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 89.
+    01 PACKET-ID        BINARY-LONG             VALUE H'59'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(64000).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/set-head-rotation.cob
+++ b/src/packets/set-head-rotation.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-SetHeadRotation.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 70.
+    01 PACKET-ID        BINARY-LONG             VALUE H'46'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(1024).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/set-player-position.cob
+++ b/src/packets/set-player-position.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-SetPlayerPosition.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 62.
+    01 PACKET-ID        BINARY-LONG             VALUE H'3E'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(64000).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/spawn-entity.cob
+++ b/src/packets/spawn-entity.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-SpawnEntity.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 1.
+    01 PACKET-ID        BINARY-LONG             VALUE H'01'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(1024).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/status.cob
+++ b/src/packets/status.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-Status.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 0.
+    01 PACKET-ID        BINARY-LONG             VALUE H'00'.
     *> buffer used to store the JSON string
     01 JSONBUFFER       PIC X(64000).
     01 JSONPOS          BINARY-LONG UNSIGNED.

--- a/src/packets/system-chat.cob
+++ b/src/packets/system-chat.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-SystemChat.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 105.
+    01 PACKET-ID        BINARY-LONG             VALUE H'69'.
     *> temporary data used during encoding
     01 UINT16           BINARY-SHORT UNSIGNED.
     01 BUFFER           PIC X(8).

--- a/src/packets/teleport-entity.cob
+++ b/src/packets/teleport-entity.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-TeleportEntity.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 109.
+    01 PACKET-ID        BINARY-LONG             VALUE H'6D'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(1024).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.

--- a/src/packets/update-time.cob
+++ b/src/packets/update-time.cob
@@ -3,7 +3,7 @@ PROGRAM-ID. SendPacket-UpdateTime.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE 98.
+    01 PACKET-ID        BINARY-LONG             VALUE H'62'.
     *> buffer used to store the packet data
     01 PAYLOAD          PIC X(16).
     01 PAYLOADLEN       BINARY-LONG UNSIGNED.


### PR DESCRIPTION
The packet listings on wiki.vg use hexadecimal notation for the packet IDs. Doing the same in the code makes it easier to reference the wiki, especially for future upgrades where packet IDs may change.