### PR TITLE
feat: Implement a server console

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following features are already working:
 - [X] breaking and placing blocks
 - [X] multiplayer
 - [X] chat
+- [X] server console commands
 - [ ] persisting data across restarts
 
 ## How-to
@@ -37,7 +38,7 @@ Or, using Docker:
 
 ```sh
 docker build -t cobolcraft .
-docker run --rm -p 25565:25565 cobolcraft
+docker run --rm -p 25565:25565 -it cobolcraft
 ```
 
 To configure the server, edit the variables in `main.cob` (limited options available).
@@ -47,7 +48,7 @@ To make it accessible from the outside (your local network, via VPN, port forwar
 can start the Docker container like this:
 
 ```sh
-docker run --rm -p 0.0.0.0:25565:25565 cobolcraft
+docker run --rm -p 0.0.0.0:25565:25565 -it cobolcraft
 ```
 
 ## Why?

--- a/src/util.cob
+++ b/src/util.cob
@@ -124,3 +124,42 @@ PROCEDURE DIVISION USING LK-BUFFER LK-VALUE.
     GOBACK.
 
 END PROGRAM Util-FloatFromBytes.
+
+*> --- Util-SetConsoleNonBlocking ---
+*> Set the console input to non-blocking mode.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. Util-SetConsoleNonBlocking.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 ERRNO            PIC 9(3).
+
+PROCEDURE DIVISION.
+    CALL "COBOLCRAFT_UTIL" USING "06" GIVING ERRNO
+    IF ERRNO NOT = 0
+        DISPLAY "Failed to set console to non-blocking mode."
+    END-IF
+    GOBACK.
+
+END PROGRAM Util-SetConsoleNonBlocking.
+
+*> --- Util-ReadConsole ---
+*> Read console input in a non-blocking manner. Returns the number of bytes read. Enter is indicated by a newline char.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. Util-ReadConsole.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 ERRNO            PIC 9(3).
+LINKAGE SECTION.
+    01 LK-BUFFER        PIC X ANY LENGTH.
+    01 LK-SIZE          BINARY-LONG.
+
+PROCEDURE DIVISION USING LK-BUFFER LK-SIZE.
+    CALL "COBOLCRAFT_UTIL" USING "07" LK-BUFFER LK-SIZE GIVING ERRNO
+    IF ERRNO NOT = 0
+        MOVE 0 TO LK-SIZE
+    END-IF
+    GOBACK.
+
+END PROGRAM Util-ReadConsole.


### PR DESCRIPTION
This patch is an initial implementation of server commands. "help" and "stop" are supported. Since GnuCOBOL's `ACCEPT` is always blocking when reading from the console, a non-blocking console read was implemented in C++.