### PR TITLE
fix: Optimize VarInt length computation

### DIFF
--- a/src/encode.cob
+++ b/src/encode.cob
@@ -122,6 +122,35 @@ PROCEDURE DIVISION USING LK-VALUE-IN LK-VALUE-OUT LK-OUT-LENGTH.
 
 END PROGRAM Encode-VarInt.
 
+*> --- Encode-GetVarIntLength ---
+*> Compute the number of bytes required to encode a signed 32-bit integer as a VarInt.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. Encode-GetVarIntLength.
+
+DATA DIVISION.
+LINKAGE SECTION.
+    01 LK-VALUE-IN          BINARY-LONG.
+    01 LK-OUT-LENGTH        BINARY-LONG UNSIGNED.
+
+PROCEDURE DIVISION USING LK-VALUE-IN LK-OUT-LENGTH.
+    EVALUATE LK-VALUE-IN
+        WHEN < 0
+            MOVE 5 TO LK-OUT-LENGTH
+        WHEN >= 268435456
+            MOVE 5 TO LK-OUT-LENGTH
+        WHEN >= 2097152
+            MOVE 4 TO LK-OUT-LENGTH
+        WHEN >= 16384
+            MOVE 3 TO LK-OUT-LENGTH
+        WHEN >= 128
+            MOVE 2 TO LK-OUT-LENGTH
+        WHEN OTHER
+            MOVE 1 TO LK-OUT-LENGTH
+    END-EVALUATE
+    GOBACK.
+
+END PROGRAM Encode-GetVarIntLength.
+
 *> --- Encode-UnsignedLong ---
 *> Encode a 64-bit unsigned integer and store it in a buffer (big-endian).
 IDENTIFICATION DIVISION.

--- a/src/packets.cob
+++ b/src/packets.cob
@@ -17,8 +17,8 @@ LINKAGE SECTION.
     01 LK-ERRNO                 PIC 9(3).
 
 PROCEDURE DIVISION USING LK-HNDL LK-PACKET-ID LK-PAYLOAD LK-PAYLOAD-LENGTH LK-ERRNO.
-    *> Encode packet ID to find the total payload length (TODO: optimize this)
-    CALL "Encode-VarInt" USING LK-PACKET-ID BUFFER NUM-BYTES
+    *> Add length of packet ID to payload length
+    CALL "Encode-GetVarIntLength" USING LK-PACKET-ID NUM-BYTES
     COMPUTE PACKET-LENGTH = NUM-BYTES + LK-PAYLOAD-LENGTH
 
     *> Send payload length

--- a/tests/encode.test.cob
+++ b/tests/encode.test.cob
@@ -5,6 +5,7 @@ PROGRAM-ID. Test-Encode.
 PROCEDURE DIVISION.
     DISPLAY "Test: encode.cob"
     CALL "Test-Encode-VarInt"
+    CALL "Test-Encode-GetVarIntLength"
     CALL "Test-Encode-Double"
     CALL "Test-Encode-Float"
     CALL "Test-Encode-Angle"
@@ -117,6 +118,103 @@ PROCEDURE DIVISION.
         GOBACK.
 
     END PROGRAM Test-Encode-VarInt.
+
+    *> --- Test: Encode-GetVarIntLength ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Test-Encode-GetVarIntLength.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        01 VALUE-IN     BINARY-LONG.
+        01 BUFFERLEN    BINARY-LONG UNSIGNED.
+
+    PROCEDURE DIVISION.
+        DISPLAY "  Test: Encode-GetVarIntLength".
+    Int0.
+        DISPLAY "    Case: 0 - " WITH NO ADVANCING
+        MOVE 0 TO VALUE-IN
+        CALL "Encode-GetVarIntLength" USING VALUE-IN BUFFERLEN
+        IF BUFFERLEN = 1
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+    Int1.
+        DISPLAY "    Case: 1 - " WITH NO ADVANCING
+        MOVE 1 TO VALUE-IN
+        CALL "Encode-GetVarIntLength" USING VALUE-IN BUFFERLEN
+        IF BUFFERLEN = 1
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+    Int127.
+        DISPLAY "    Case: 127 - " WITH NO ADVANCING
+        MOVE 127 TO VALUE-IN
+        CALL "Encode-GetVarIntLength" USING VALUE-IN BUFFERLEN
+        IF BUFFERLEN = 1
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+    Int128.
+        DISPLAY "    Case: 128 - " WITH NO ADVANCING
+        MOVE 128 TO VALUE-IN
+        CALL "Encode-GetVarIntLength" USING VALUE-IN BUFFERLEN
+        IF BUFFERLEN = 2
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+    Int255.
+        DISPLAY "    Case: 255 - " WITH NO ADVANCING
+        MOVE 255 TO VALUE-IN
+        CALL "Encode-GetVarIntLength" USING VALUE-IN BUFFERLEN
+        IF BUFFERLEN = 2
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+    Int25565.
+        DISPLAY "    Case: 25565 - " WITH NO ADVANCING
+        MOVE 25565 TO VALUE-IN
+        CALL "Encode-GetVarIntLength" USING VALUE-IN BUFFERLEN
+        IF BUFFERLEN = 3
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+    IntMax.
+        DISPLAY "    Case: 2147483647 - " WITH NO ADVANCING
+        MOVE 2147483647 TO VALUE-IN
+        CALL "Encode-GetVarIntLength" USING VALUE-IN BUFFERLEN
+        IF BUFFERLEN = 5
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+    IntNegative1.
+        DISPLAY "    Case: -1 - " WITH NO ADVANCING
+        MOVE -1 TO VALUE-IN
+        CALL "Encode-GetVarIntLength" USING VALUE-IN BUFFERLEN
+        IF BUFFERLEN = 5
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+    IntMin.
+        DISPLAY "    Case: -2147483648 - " WITH NO ADVANCING
+        MOVE -2147483648 TO VALUE-IN
+        CALL "Encode-GetVarIntLength" USING VALUE-IN BUFFERLEN
+        IF BUFFERLEN = 5
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+
+        GOBACK.
+
+    END PROGRAM Test-Encode-GetVarIntLength.
 
     *> --- Test: Encode-Double ---
     IDENTIFICATION DIVISION.


### PR DESCRIPTION
This patch adds a helper to compute the length of an integer encoded as VarInt without having to do the encoding, to improve performance.