### PR TITLE
fix: Optimize parsing of blocks.json

### DIFF
--- a/src/blocks.cob
+++ b/src/blocks.cob
@@ -5,10 +5,11 @@ PROGRAM-ID. Blocks-Parse.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 OFFSET           BINARY-LONG UNSIGNED.
-    01 EXIT-LOOP        BINARY-CHAR UNSIGNED.
     *> shared data
     COPY DD-BLOCKS.
+LOCAL-STORAGE SECTION.
+    01 OFFSET           BINARY-LONG UNSIGNED    VALUE 1.
+    01 EXIT-LOOP        BINARY-CHAR UNSIGNED    VALUE 0.
 LINKAGE SECTION.
     01 LK-JSON          PIC X ANY LENGTH.
     01 LK-JSON-LEN      BINARY-LONG UNSIGNED.
@@ -17,28 +18,16 @@ LINKAGE SECTION.
 PROCEDURE DIVISION USING LK-JSON LK-JSON-LEN LK-FAILURE.
     MOVE 0 TO BLOCKS-COUNT
 
-    MOVE 1 TO OFFSET
-
     *> Expect start of the root object.
     CALL "JsonParse-ObjectStart" USING LK-JSON OFFSET LK-FAILURE
-    IF LK-FAILURE NOT = 0
-        GOBACK
-    END-IF
 
-    *> Loop over each key in the root object, each representing a block.
-    PERFORM UNTIL EXIT
-        *> Read the block.
+    *> Each key in the root object represents a block.
+    PERFORM UNTIL LK-FAILURE NOT = 0 OR EXIT-LOOP = 1
         ADD 1 TO BLOCKS-COUNT
         CALL "Blocks-Parse-Block" USING LK-JSON OFFSET LK-FAILURE BLOCKS-COUNT
-        IF LK-FAILURE NOT = 0
-            GOBACK
-        END-IF
 
-        *> Check if there is a comma; if not, exit the loop.
+        *> Continue reading if there is a comma.
         CALL "JsonParse-Comma" USING LK-JSON OFFSET EXIT-LOOP
-        IF EXIT-LOOP = 1
-            EXIT PERFORM
-        END-IF
     END-PERFORM
 
     *> Expect end of the root object.
@@ -53,7 +42,7 @@ PROCEDURE DIVISION USING LK-JSON LK-JSON-LEN LK-FAILURE.
     DATA DIVISION.
     WORKING-STORAGE SECTION.
         01 EXIT-LOOP        BINARY-CHAR UNSIGNED.
-        01 OBJECT-KEY       PIC X(100).
+        01 OBJECT-KEY       PIC X(50).
         01 STATE-ID         BINARY-LONG UNSIGNED.
         01 IS-DEFAULT       BINARY-CHAR UNSIGNED.
         *> shared data
@@ -65,24 +54,19 @@ PROCEDURE DIVISION USING LK-JSON LK-JSON-LEN LK-FAILURE.
         01 LK-BLOCK         BINARY-LONG UNSIGNED.
 
     PROCEDURE DIVISION USING LK-JSON LK-OFFSET LK-FAILURE LK-BLOCK.
+        MOVE 0 TO BLOCK-ENTRY-PROPERTY-COUNT(LK-BLOCK)
         MOVE 999999999 TO BLOCK-ENTRY-MINIMUM-STATE-ID(LK-BLOCK)
         MOVE 0 TO BLOCK-ENTRY-MAXIMUM-STATE-ID(LK-BLOCK)
         MOVE 0 TO BLOCK-ENTRY-DEFAULT-STATE-ID(LK-BLOCK)
 
         *> Read the block name.
         CALL "JsonParse-ObjectKey" USING LK-JSON LK-OFFSET LK-FAILURE BLOCK-ENTRY-NAME(LK-BLOCK)
-        IF LK-FAILURE NOT = 0
-            GOBACK
-        END-IF
 
         *> Expect start of the block object.
         CALL "JsonParse-ObjectStart" USING LK-JSON LK-OFFSET LK-FAILURE
-        IF LK-FAILURE NOT = 0
-            GOBACK
-        END-IF
 
         *> Loop over each key in the object.
-        PERFORM UNTIL EXIT
+        PERFORM UNTIL LK-FAILURE NOT = 0
             *> Read the key.
             CALL "JsonParse-ObjectKey" USING LK-JSON LK-OFFSET LK-FAILURE OBJECT-KEY
             IF LK-FAILURE NOT = 0
@@ -93,18 +77,12 @@ PROCEDURE DIVISION USING LK-JSON LK-JSON-LEN LK-FAILURE.
                 WHEN "properties"
                     *> Expect the start of the properties object.
                     CALL "JsonParse-ObjectStart" USING LK-JSON LK-OFFSET LK-FAILURE
-                    IF LK-FAILURE NOT = 0
-                        GOBACK
-                    END-IF
 
                     *> Loop over each key in the properties object, each representing a block property.
-                    PERFORM UNTIL EXIT
+                    PERFORM UNTIL LK-FAILURE NOT = 0
                         *> Read the property.
                         ADD 1 TO BLOCK-ENTRY-PROPERTY-COUNT(LK-BLOCK)
                         CALL "Blocks-Parse-Property" USING LK-JSON LK-OFFSET LK-FAILURE BLOCK-ENTRY-PROPERTY(LK-BLOCK, BLOCK-ENTRY-PROPERTY-COUNT(LK-BLOCK))
-                        IF LK-FAILURE NOT = 0
-                            GOBACK
-                        END-IF
 
                         *> Check if there is a comma; if not, exit the loop.
                         CALL "JsonParse-Comma" USING LK-JSON LK-OFFSET EXIT-LOOP
@@ -115,27 +93,18 @@ PROCEDURE DIVISION USING LK-JSON LK-JSON-LEN LK-FAILURE.
 
                     *> Expect the end of the properties object.
                     CALL "JsonParse-ObjectEnd" USING LK-JSON LK-OFFSET LK-FAILURE
-                    IF LK-FAILURE NOT = 0
-                        GOBACK
-                    END-IF
 
                 WHEN "states"
                     *> Expect the start of the states array.
                     CALL "JsonParse-ArrayStart" USING LK-JSON LK-OFFSET LK-FAILURE
-                    IF LK-FAILURE NOT = 0
-                        GOBACK
-                    END-IF
 
                     *> Loop over each key in the states array, each representing a block state.
-                    PERFORM UNTIL EXIT
+                    PERFORM UNTIL LK-FAILURE NOT = 0
                         *> Read the state.
                         CALL "Blocks-Parse-State" USING LK-JSON LK-OFFSET LK-FAILURE STATE-ID IS-DEFAULT
-                        IF LK-FAILURE NOT = 0
-                            GOBACK
-                        END-IF
 
-                        COMPUTE BLOCK-ENTRY-MINIMUM-STATE-ID(LK-BLOCK) = FUNCTION MIN(BLOCK-ENTRY-MINIMUM-STATE-ID(LK-BLOCK), STATE-ID)
-                        COMPUTE BLOCK-ENTRY-MAXIMUM-STATE-ID(LK-BLOCK) = FUNCTION MAX(BLOCK-ENTRY-MAXIMUM-STATE-ID(LK-BLOCK), STATE-ID)
+                        MOVE FUNCTION MIN(BLOCK-ENTRY-MINIMUM-STATE-ID(LK-BLOCK), STATE-ID) TO BLOCK-ENTRY-MINIMUM-STATE-ID(LK-BLOCK)
+                        MOVE FUNCTION MAX(BLOCK-ENTRY-MAXIMUM-STATE-ID(LK-BLOCK), STATE-ID) TO BLOCK-ENTRY-MAXIMUM-STATE-ID(LK-BLOCK)
                         IF IS-DEFAULT > 0
                             MOVE STATE-ID TO BLOCK-ENTRY-DEFAULT-STATE-ID(LK-BLOCK)
                         END-IF
@@ -149,15 +118,9 @@ PROCEDURE DIVISION USING LK-JSON LK-JSON-LEN LK-FAILURE.
 
                     *> Expect the end of the states array.
                     CALL "JsonParse-ArrayEnd" USING LK-JSON LK-OFFSET LK-FAILURE
-                    IF LK-FAILURE NOT = 0
-                        GOBACK
-                    END-IF
 
                 WHEN OTHER
                     CALL "JsonParse-SkipValue" USING LK-JSON LK-OFFSET LK-FAILURE
-                    IF LK-FAILURE NOT = 0
-                        GOBACK
-                    END-IF
             END-EVALUATE
 
             *> Check if there is a comma; if not, exit the loop.
@@ -184,32 +147,24 @@ PROCEDURE DIVISION USING LK-JSON LK-JSON-LEN LK-FAILURE.
             01 LK-OFFSET        BINARY-LONG UNSIGNED.
             01 LK-FAILURE       BINARY-CHAR UNSIGNED.
             01 LK-PROPERTY.
-                02 LK-PROPERTY-NAME         PIC X(64).
+                02 LK-PROPERTY-NAME         PIC X(32).
                 02 LK-PROPERTY-VALUE-COUNT  BINARY-LONG UNSIGNED.
-                02 LK-PROPERTY-VALUE OCCURS 32 TIMES.
-                    03 LK-PROPERTY-VALUE-NAME  PIC X(64).
+                02 LK-PROPERTY-VALUE        PIC X(32) OCCURS 32 TIMES.
 
         PROCEDURE DIVISION USING LK-JSON LK-OFFSET LK-FAILURE LK-PROPERTY.
+            MOVE 0 TO LK-PROPERTY-VALUE-COUNT
+
             *> Read the property name.
             CALL "JsonParse-ObjectKey" USING LK-JSON LK-OFFSET LK-FAILURE LK-PROPERTY-NAME
-            IF LK-FAILURE NOT = 0
-                GOBACK
-            END-IF
 
             *> Expect the start of the property value array.
             CALL "JsonParse-ArrayStart" USING LK-JSON LK-OFFSET LK-FAILURE
-            IF LK-FAILURE NOT = 0
-                GOBACK
-            END-IF
 
             *> Loop over each value in the array.
-            PERFORM UNTIL EXIT
+            PERFORM UNTIL LK-FAILURE NOT = 0
                 *> Read the value.
                 ADD 1 TO LK-PROPERTY-VALUE-COUNT
                 CALL "JsonParse-String" USING LK-JSON LK-OFFSET LK-FAILURE LK-PROPERTY-VALUE(LK-PROPERTY-VALUE-COUNT)
-                IF LK-FAILURE NOT = 0
-                    GOBACK
-                END-IF
 
                 *> Check if there is a comma; if not, exit the loop.
                 CALL "JsonParse-Comma" USING LK-JSON LK-OFFSET EXIT-LOOP
@@ -232,7 +187,7 @@ PROCEDURE DIVISION USING LK-JSON LK-JSON-LEN LK-FAILURE.
         DATA DIVISION.
         WORKING-STORAGE SECTION.
             01 EXIT-LOOP            BINARY-CHAR UNSIGNED.
-            01 OBJECT-KEY           PIC X(100).
+            01 OBJECT-KEY           PIC X(50).
         LINKAGE SECTION.
             01 LK-JSON              PIC X ANY LENGTH.
             01 LK-OFFSET            BINARY-LONG UNSIGNED.

--- a/src/copybooks/DD-BLOCKS.cpy
+++ b/src/copybooks/DD-BLOCKS.cpy
@@ -8,9 +8,9 @@
         *> to store the properties instead of one array per state.
         03 BLOCK-ENTRY-PROPERTY-COUNT BINARY-LONG UNSIGNED.
         03 BLOCK-ENTRY-PROPERTY OCCURS 16 TIMES.
-            04 BLOCK-ENTRY-PROPERTY-NAME PIC X(64).
+            04 BLOCK-ENTRY-PROPERTY-NAME PIC X(32).
             04 BLOCK-ENTRY-PROPERTY-VALUE-COUNT BINARY-LONG UNSIGNED.
-            04 BLOCK-ENTRY-PROPERTY-VALUE PIC X(64) OCCURS 32 TIMES.
+            04 BLOCK-ENTRY-PROPERTY-VALUE PIC X(32) OCCURS 32 TIMES.
         *> Some blocks have a lot of states. For instance, redstone wire has 1296 states (3 power states per
         *> north/east/south/west * 15 power levels).
         *> To save memory, we only store the minimum and maximum IDs instead of the entire list.

--- a/src/server.cob
+++ b/src/server.cob
@@ -12,9 +12,9 @@ FILE-CONTROL.
 DATA DIVISION.
 FILE SECTION.
     FD FD-REGISTRIES-FILE.
-        01 REGISTRIES-LINE PIC X(1024).
+        01 REGISTRIES-LINE PIC X(255).
     FD FD-BLOCKS-FILE.
-        01 BLOCKS-LINE PIC X(1024).
+        01 BLOCKS-LINE PIC X(255).
 
 WORKING-STORAGE SECTION.
     *> Constants
@@ -121,16 +121,13 @@ LoadRegistries.
     *> read the entire registries.json file into memory
     MOVE 0 TO DATA-BUFFER-LEN
     OPEN INPUT FD-REGISTRIES-FILE
-    MOVE 1024 TO BYTE-COUNT
+    MOVE 1 TO BYTE-COUNT
     PERFORM UNTIL BYTE-COUNT = 0
         READ FD-REGISTRIES-FILE
             AT END
                 MOVE 0 TO BYTE-COUNT
             NOT AT END
-                IF DATA-BUFFER-LEN > 0
-                    MOVE " " TO DATA-BUFFER(DATA-BUFFER-LEN + 1:1)
-                    ADD 1 TO DATA-BUFFER-LEN
-                END-IF
+                *> Note: This swallows the newline, which is fine for JSON data.
                 MOVE FUNCTION STORED-CHAR-LENGTH(REGISTRIES-LINE) TO TEMP-INT32
                 MOVE REGISTRIES-LINE(1:TEMP-INT32) TO DATA-BUFFER(DATA-BUFFER-LEN + 1:TEMP-INT32)
                 ADD TEMP-INT32 TO DATA-BUFFER-LEN
@@ -150,16 +147,13 @@ LoadBlocks.
     *> read the entire blocks.json file into memory
     MOVE 0 TO DATA-BUFFER-LEN
     OPEN INPUT FD-BLOCKS-FILE
-    MOVE 1024 TO BYTE-COUNT
+    MOVE 1 TO BYTE-COUNT
     PERFORM UNTIL BYTE-COUNT = 0
         READ FD-BLOCKS-FILE
             AT END
                 MOVE 0 TO BYTE-COUNT
             NOT AT END
-                IF DATA-BUFFER-LEN > 0
-                    MOVE " " TO DATA-BUFFER(DATA-BUFFER-LEN + 1:1)
-                    ADD 1 TO DATA-BUFFER-LEN
-                END-IF
+                *> Note: This swallows the newline, which is fine for JSON data.
                 MOVE FUNCTION STORED-CHAR-LENGTH(BLOCKS-LINE) TO TEMP-INT32
                 MOVE BLOCKS-LINE(1:TEMP-INT32) TO DATA-BUFFER(DATA-BUFFER-LEN + 1:TEMP-INT32)
                 ADD TEMP-INT32 TO DATA-BUFFER-LEN

--- a/tests/json-parse.test.cob
+++ b/tests/json-parse.test.cob
@@ -720,6 +720,17 @@ PROCEDURE DIVISION.
         ELSE
             DISPLAY "FAIL"
         END-IF.
+    ScientificNotation.
+        DISPLAY "    Case: '    1.23e-4  ' - " WITH NO ADVANCING
+        MOVE "    1.23e-4  " TO STR
+        MOVE 1 TO OFFSET
+        MOVE 1 TO FLAG
+        CALL "JsonParse-SkipValue" USING STR OFFSET FLAG
+        IF OFFSET = 12 AND FLAG = 0
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
     StringValue.
         DISPLAY "    Case: '    ""abc""  ' - " WITH NO ADVANCING
         MOVE "    ""abc""  " TO STR
@@ -727,6 +738,17 @@ PROCEDURE DIVISION.
         MOVE 1 TO FLAG
         CALL "JsonParse-SkipValue" USING STR OFFSET FLAG
         IF OFFSET = 10 AND FLAG = 0
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+    StringEscape.
+        DISPLAY "    Case: '    ""1\""2\\3\/4\b5\f6\n7\r8\t9""  ' - " WITH NO ADVANCING
+        MOVE "    ""1\""2\\3\/4\b5\f6\n7\r8\t9""  " TO STR
+        MOVE 1 TO OFFSET
+        MOVE 1 TO FLAG
+        CALL "JsonParse-SkipValue" USING STR OFFSET FLAG
+        IF OFFSET = 32 AND FLAG = 0
             DISPLAY "PASS"
         ELSE
             DISPLAY "FAIL"


### PR DESCRIPTION
This patch improves the performance of JSON parsing, and parsing of blocks.json in particular. Overall, a reduction from 1050ms down to 460ms is observed.

The benefits come mostly from the removal of redundant operations: Explicit failure checks, for instance, can often be avoided without downsides if the next instruction(s) are able to deal with a failure condition themselves already.

Further improvements are possible by avoiding string parsing in JsonParse-SkipValue, and avoiding repetitive calls to LENGTH.