### PR TITLE
feat: Add support for all slab types

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following features are already working:
 
 Note that blocks with multiple states and/or orientations require large amounts of specialized code to make them
 behave properly, which is way beyond the scope of this project.
-Some are supported, however (currently: all torch variants, stone slabs).
+Some are supported, however (currently: all torch variants, all slab types).
 
 ## How-to
 

--- a/src/copybooks/DD-BLOCKS.cpy
+++ b/src/copybooks/DD-BLOCKS.cpy
@@ -3,6 +3,8 @@
     02 BLOCKS-COUNT BINARY-LONG UNSIGNED.
     02 BLOCK-ENTRY OCCURS 2000 TIMES.
         03 BLOCK-ENTRY-NAME PIC X(100).
+        *> The value of "definition"."type". For example, "minecraft:slab" for slab blocks.
+        03 BLOCK-ENTRY-TYPE PIC X(100).
         *> We make use of the fact that each block state corresponds to a combination of properties,
         *> and that they occur in a predictable order. This allows us to use a single array per block
         *> to store the properties instead of one array per state.

--- a/src/items/slab.cob
+++ b/src/items/slab.cob
@@ -5,13 +5,26 @@ PROGRAM-ID. RegisterItem-Slab.
 DATA DIVISION.
 WORKING-STORAGE SECTION.
     01 C-MINECRAFT-AIR                  PIC X(32) GLOBAL    VALUE "minecraft:air".
-    01 C-MINECRAFT-STONE_SLAB           PIC X(32) GLOBAL    VALUE "minecraft:stone_slab".
+    01 C-MINECRAFT-SLAB                 PIC X(32) GLOBAL    VALUE "minecraft:slab".
     01 USE-PTR                          PROGRAM-POINTER.
+    01 BLOCK-COUNT                      BINARY-LONG UNSIGNED.
+    01 BLOCK-INDEX                      BINARY-LONG UNSIGNED.
+    01 BLOCK-NAME                       PIC X(64).
+    01 BLOCK-TYPE                       PIC X(64).
 
 PROCEDURE DIVISION.
     SET USE-PTR TO ENTRY "Callback-Use"
-    *> TODO implement all slab types - can be done by checking "definition"."type" == "minecraft:slab" in blocks.json
-    CALL "SetCallback-ItemUse" USING C-MINECRAFT-STONE_SLAB USE-PTR
+
+    *> Loop over all blocks and register the callback for each slab
+    CALL "Blocks-GetCount" USING BLOCK-COUNT
+    PERFORM VARYING BLOCK-INDEX FROM 1 BY 1 UNTIL BLOCK-INDEX > BLOCK-COUNT
+        CALL "Blocks-Iterate-Type" USING BLOCK-INDEX BLOCK-TYPE
+        IF BLOCK-TYPE = C-MINECRAFT-SLAB
+            CALL "Blocks-Iterate-Name" USING BLOCK-INDEX BLOCK-NAME
+            CALL "SetCallback-ItemUse" USING BLOCK-NAME USE-PTR
+        END-IF
+    END-PERFORM
+
     GOBACK.
 
     *> --- Callback-Use ---


### PR DESCRIPTION
As described in the previous PR, #107, we now parse the type attribute of blocks in the blocks.json file - this can then be used to iterate over blocks looking for a type of "minecraft:slab", such that the slab placement handler is automatically registered for each slab type.