### PR TITLE
fix: Improve slab doubling when placed

### DIFF
--- a/src/items/slab.cob
+++ b/src/items/slab.cob
@@ -98,14 +98,11 @@ PROCEDURE DIVISION.
             CALL "Blocks-Get-StateDescription" USING BLOCK-ID CURRENT-DESCRIPTION
             IF CURRENT-NAME = SLAB-NAME
                 CALL "Blocks-Description-GetValue" USING CURRENT-DESCRIPTION C-TYPE CURRENT-TYPE
-                EVALUATE SLAB-PROPERTY-VALUE(1) ALSO CURRENT-TYPE
-                    WHEN "top" ALSO "bottom"
-                        MOVE "double" TO SLAB-PROPERTY-VALUE(1)
-                    WHEN "bottom" ALSO "top"
-                        MOVE "double" TO SLAB-PROPERTY-VALUE(1)
-                    WHEN OTHER
-                        GOBACK
-                END-EVALUATE
+                *> Counter-intuitively, Minecraft does not care about the slab type here, only that it is a single slab
+                IF CURRENT-TYPE = "double"
+                    GOBACK
+                END-IF
+                MOVE "double" TO SLAB-PROPERTY-VALUE(1)
             END-IF
         END-IF
 


### PR DESCRIPTION
We now correctly handle an edge-case of slab placement. Imagine a single bottom slab of block type X, and above it a single bottom slab of a different type Y. When the player has a Y slab in their hand and clicks the bottom slab on its top face, one would imagine that no block placement happens, since clicking a top face usually places a bottom slab above the clicked block, but a bottom slab of type Y is already present there, blocking placement. However, this is not what Minecraft does. Instead, the Y slab is placed through the existing Y slab, doubling it. This case is now properly handled. Similar behavior is observed when clicking the sides of blocks with unusual geometry, such as hoppers, which now work as expected, too.