### PR TITLE
feat: Add zlib compression functions

### DIFF
--- a/cpp/cobolcraft_util.cpp
+++ b/cpp/cobolcraft_util.cpp
@@ -90,6 +90,88 @@ EXTERN_DECL int LeadingZeros32(unsigned long *value, unsigned long *count)
     return 0;
 }
 
+EXTERN_DECL int ZlibCompress(char *decompressed, unsigned long *decompressed_length, char *compressed, unsigned long *compressed_length)
+{
+    if (!decompressed || !decompressed_length || !compressed || !compressed_length)
+    {
+        return ERRNO_PARAMS;
+    }
+
+    if (*decompressed_length == 0)
+    {
+        *compressed_length = 0;
+        return 0;
+    }
+
+    z_stream stream;
+    stream.zalloc = Z_NULL;
+    stream.zfree = Z_NULL;
+    stream.opaque = Z_NULL;
+    stream.avail_in = *decompressed_length;
+    stream.next_in = (Bytef *)decompressed;
+    stream.avail_out = *compressed_length;
+    stream.next_out = (Bytef *)compressed;
+
+    int result = deflateInit(&stream, Z_DEFAULT_COMPRESSION);
+    if (result != Z_OK)
+    {
+        return ERRNO_SYSTEM;
+    }
+
+    result = deflate(&stream, Z_FINISH);
+    if (result != Z_STREAM_END)
+    {
+        deflateEnd(&stream);
+        return ERRNO_SYSTEM;
+    }
+
+    *compressed_length = stream.total_out;
+    deflateEnd(&stream);
+
+    return 0;
+}
+
+EXTERN_DECL int ZlibDecompress(char *compressed, unsigned long *compressed_length, char *decompressed, unsigned long *decompressed_length)
+{
+    if (!compressed || !compressed_length || !decompressed || !decompressed_length)
+    {
+        return ERRNO_PARAMS;
+    }
+
+    if (*compressed_length == 0)
+    {
+        *decompressed_length = 0;
+        return 0;
+    }
+
+    z_stream stream;
+    stream.zalloc = Z_NULL;
+    stream.zfree = Z_NULL;
+    stream.opaque = Z_NULL;
+    stream.avail_in = *compressed_length;
+    stream.next_in = (Bytef *)compressed;
+    stream.avail_out = *decompressed_length;
+    stream.next_out = (Bytef *)decompressed;
+
+    int result = inflateInit(&stream);
+    if (result != Z_OK)
+    {
+        return ERRNO_SYSTEM;
+    }
+
+    result = inflate(&stream, Z_FINISH);
+    if (result != Z_STREAM_END)
+    {
+        inflateEnd(&stream);
+        return ERRNO_SYSTEM;
+    }
+
+    *decompressed_length = stream.total_out;
+    inflateEnd(&stream);
+
+    return 0;
+}
+
 EXTERN_DECL int GzipCompress(char *decompressed, unsigned long *decompressed_length, char *compressed, unsigned long *compressed_length)
 {
     if (!decompressed || !decompressed_length || !compressed || !compressed_length)

--- a/cpp/cobolcraft_util.h
+++ b/cpp/cobolcraft_util.h
@@ -27,6 +27,18 @@ EXTERN_DECL int ReadConsole(char *buffer, unsigned long *count);
 EXTERN_DECL int LeadingZeros32(unsigned long *value, unsigned long *count);
 
 /**
+ * Compress a buffer using zlib (deflate). The compressed length indicates the size of the compressed buffer; after compression,
+ * it contains the actual size of the compressed data.
+ */
+EXTERN_DECL int ZlibCompress(char *decompressed, unsigned long *decompressed_length, char *compressed, unsigned long *compressed_length);
+
+/**
+ * Decompress a zlib-compressed buffer. The decompressed length indicates the size of the decompressed buffer; after
+ * decompression, it contains the actual size of the decompressed data.
+ */
+EXTERN_DECL int ZlibDecompress(char *compressed, unsigned long *compressed_length, char *decompressed, unsigned long *decompressed_length);
+
+/**
  * Compress a buffer using gzip. The compressed length indicates the size of the compressed buffer; after compression,
  * it contains the actual size of the compressed data.
  */

--- a/tests/cobolcraft_util.test.cob
+++ b/tests/cobolcraft_util.test.cob
@@ -5,6 +5,8 @@ PROGRAM-ID. Test-Util.
 PROCEDURE DIVISION.
     DISPLAY "Test: cobolcraft_util.cpp"
     CALL "Test-LeadingZeros32"
+    CALL "Test-ZlibCompress"
+    CALL "Test-ZlibDecompress"
     CALL "Test-GzipCompress"
     CALL "Test-GzipDecompress"
     GOBACK.
@@ -69,6 +71,68 @@ PROCEDURE DIVISION.
         GOBACK.
 
     END PROGRAM Test-LeadingZeros32.
+
+    *> --- Test: Test-ZlibCompress ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Test-ZlibCompress.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        01 INPUT-BUFFER         PIC X(100).
+        01 OUTPUT-BUFFER        PIC X(100).
+        01 INPUT-LENGTH         BINARY-LONG UNSIGNED.
+        01 OUTPUT-LENGTH        BINARY-LONG UNSIGNED.
+        01 ERRNO                BINARY-LONG UNSIGNED.
+
+    PROCEDURE DIVISION.
+        DISPLAY "  Test: Test-ZlibCompress".
+    Basic.
+        DISPLAY "    Case: Basic - " WITH NO ADVANCING
+        MOVE "Hello, World!" TO INPUT-BUFFER
+        MOVE 13 TO INPUT-LENGTH
+        MOVE SPACES TO OUTPUT-BUFFER
+        MOVE LENGTH OF OUTPUT-BUFFER TO OUTPUT-LENGTH
+        CALL "ZlibCompress" USING INPUT-BUFFER INPUT-LENGTH OUTPUT-BUFFER OUTPUT-LENGTH GIVING ERRNO
+        IF ERRNO = 0 AND OUTPUT-LENGTH = 21 AND OUTPUT-BUFFER(1:21) = X"789CF348CDC9C9D75108CF2FCA495104001F9E046A"
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+
+        GOBACK.
+
+    END PROGRAM Test-ZlibCompress.
+
+    *> --- Test: Test-ZlibDecompress ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Test-ZlibDecompress.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        01 INPUT-BUFFER         PIC X(100).
+        01 OUTPUT-BUFFER        PIC X(100).
+        01 INPUT-LENGTH         BINARY-LONG UNSIGNED.
+        01 OUTPUT-LENGTH        BINARY-LONG UNSIGNED.
+        01 ERRNO                BINARY-LONG UNSIGNED.
+
+    PROCEDURE DIVISION.
+        DISPLAY "  Test: Test-ZlibDecompress".
+    Basic.
+        DISPLAY "    Case: Basic - " WITH NO ADVANCING
+        MOVE X"789CF348CDC9C9D75108CF2FCA495104001F9E046A" TO INPUT-BUFFER
+        MOVE 21 TO INPUT-LENGTH
+        MOVE SPACES TO OUTPUT-BUFFER
+        MOVE LENGTH OF OUTPUT-BUFFER TO OUTPUT-LENGTH
+        CALL "ZlibDecompress" USING INPUT-BUFFER INPUT-LENGTH OUTPUT-BUFFER OUTPUT-LENGTH GIVING ERRNO
+        IF ERRNO = 0 AND OUTPUT-LENGTH = 13 AND OUTPUT-BUFFER(1:13) = "Hello, World!"
+            DISPLAY "PASS"
+        ELSE
+            DISPLAY "FAIL"
+        END-IF.
+
+        GOBACK.
+
+    END PROGRAM Test-ZlibDecompress.
 
     *> --- Test: Test-GzipCompress ---
     IDENTIFICATION DIVISION.


### PR DESCRIPTION
This patch is made in preparation for supporting the "Anvil" region format, which requires zlib/deflate compression and decompression.