### PR TITLE
fix: Optimize chunk loading

### DIFF
--- a/src/copybooks/DD-WORLD.cpy
+++ b/src/copybooks/DD-WORLD.cpy
@@ -16,5 +16,6 @@
         03 WORLD-SECTION OCCURS WORLD-SECTION-COUNT TIMES.
             04 WORLD-SECTION-NON-AIR    BINARY-LONG UNSIGNED.
             *> block IDs (16x16x16) - X increases fastest, then Z, then Y
-            04 WORLD-BLOCK OCCURS 4096 TIMES.
-                05 WORLD-BLOCK-ID           BINARY-LONG UNSIGNED.
+            04 WORLD-SECTION-BLOCKS.
+                05 WORLD-BLOCK OCCURS 4096 TIMES.
+                    06 WORLD-BLOCK-ID           BINARY-LONG UNSIGNED.


### PR DESCRIPTION
This patch significantly reduces the chunk loading time in a flat world, and likely in any other world type, too. Performance improvements of 55% were measured. The largest reductions come from using an INITIALIZE statement to set an entire chunk to a single block type, and from precomputing `2 ** PALETTE-BITS` and using a single DIVIDE statement with a REMAINDER clause.

Each partial change in this patch was independently checked to ensure there are no regressions anywhere.