### PR TITLE
chore: Support building in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 *.so
+/out
 /cobolcraft
 /data
 /test

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY src ./src
 COPY cpp ./cpp
 COPY CBL_GC_SOCKET ./CBL_GC_SOCKET
 COPY blobs ./blobs
-RUN make
+RUN make -j $(nproc)
 
 # --- Runtime stage ---
 FROM ubuntu:jammy


### PR DESCRIPTION
By generating output files as individual Make targets and linking only as the final step, it becomes possible to build in parallel: e.g. `make -j $(nproc)` to use the available number of CPU cores. On a 12-core, 24-thread system, this reduces the build time by 75% with much of the remaining time spent linking, which is unavoidable. Additionally, incremental builds are now possible, where not every source file has to be recompiled if just one has changed.