### PR TITLE
feat: Add support for doors, with open/close interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Some are supported, however:
 - slabs (all variants)
 - rotated pillars, such as logs or basalt
 - buttons (non-interactive)
+- doors (including interaction)
 - trapdoors (including interaction)
 - beds
 

--- a/src/blocks/door.cob
+++ b/src/blocks/door.cob
@@ -1,0 +1,101 @@
+*> --- RegisterBlock-Door ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterBlock-Door.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 C-MINECRAFT-DOOR                 PIC X(32) GLOBAL    VALUE "minecraft:door".
+    01 USE-PTR                          PROGRAM-POINTER.
+    01 BLOCK-COUNT                      BINARY-LONG UNSIGNED.
+    01 BLOCK-INDEX                      BINARY-LONG UNSIGNED.
+    01 BLOCK-TYPE                       PIC X(64).
+    01 BLOCK-MINIMUM-STATE-ID           BINARY-LONG.
+    01 BLOCK-MAXIMUM-STATE-ID           BINARY-LONG.
+    01 STATE-ID                         BINARY-LONG.
+
+PROCEDURE DIVISION.
+    SET USE-PTR TO ENTRY "Callback-Interact"
+
+    *> Loop over all blocks and register the callback for each door
+    CALL "Blocks-GetCount" USING BLOCK-COUNT
+    PERFORM VARYING BLOCK-INDEX FROM 1 BY 1 UNTIL BLOCK-INDEX > BLOCK-COUNT
+        CALL "Blocks-Iterate-Type" USING BLOCK-INDEX BLOCK-TYPE
+        *> TODO check for door block type (e.g., iron doors cannot be opened by clicking)
+        IF BLOCK-TYPE = C-MINECRAFT-DOOR
+            CALL "Blocks-Iterate-StateIds" USING BLOCK-INDEX BLOCK-MINIMUM-STATE-ID BLOCK-MAXIMUM-STATE-ID
+            PERFORM VARYING STATE-ID FROM BLOCK-MINIMUM-STATE-ID BY 1 UNTIL STATE-ID > BLOCK-MAXIMUM-STATE-ID
+                CALL "SetCallback-BlockInteract" USING STATE-ID USE-PTR
+            END-PERFORM
+        END-IF
+    END-PERFORM
+
+    GOBACK.
+
+    *> --- Callback-Interact ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Interact.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        01 C-HALF                   PIC X(4)                VALUE "half".
+        01 C-OPEN                   PIC X(4)                VALUE "open".
+        COPY DD-PLAYERS.
+        01 BLOCK-ID                 BINARY-LONG.
+        COPY DD-BLOCK-STATE REPLACING LEADING ==PREFIX== BY ==CLICKED==.
+        COPY DD-BLOCK-STATE REPLACING LEADING ==PREFIX== BY ==OTHER-HALF==.
+        01 HALF-VALUE-CLICKED       PIC X(16).
+        01 HALF-VALUE-OTHER         PIC X(16).
+        01 OPEN-VALUE               PIC X(16).
+        01 BLOCK-POSITION.
+            02 BLOCK-X              BINARY-LONG.
+            02 BLOCK-Y              BINARY-LONG.
+            02 BLOCK-Z              BINARY-LONG.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-BLOCK-INTERACT.
+
+    PROCEDURE DIVISION USING LK-PLAYER LK-ITEM-NAME LK-POSITION LK-FACE LK-CURSOR.
+        *> Obtain the current block state description
+        CALL "World-GetBlock" USING LK-POSITION BLOCK-ID
+        CALL "Blocks-Get-StateDescription" USING BLOCK-ID CLICKED-DESCRIPTION
+
+        *> Toggle the "open" property for the clicked half
+        CALL "Blocks-Description-GetValue" USING CLICKED-DESCRIPTION C-OPEN OPEN-VALUE
+        IF OPEN-VALUE = "true"
+            MOVE "false" TO OPEN-VALUE
+        ELSE
+            MOVE "true" TO OPEN-VALUE
+        END-IF
+        CALL "Blocks-Description-SetValue" USING CLICKED-DESCRIPTION C-OPEN OPEN-VALUE
+        CALL "Blocks-Get-StateId" USING CLICKED-DESCRIPTION BLOCK-ID
+        CALL "World-SetBlock" USING PLAYER-CLIENT(LK-PLAYER) LK-POSITION BLOCK-ID
+
+        *> Find the other half
+        CALL "Blocks-Description-GetValue" USING CLICKED-DESCRIPTION C-HALF HALF-VALUE-CLICKED
+        MOVE LK-POSITION TO BLOCK-POSITION
+        IF HALF-VALUE-CLICKED = "upper"
+            SUBTRACT 1 FROM BLOCK-Y
+        ELSE
+            ADD 1 TO BLOCK-Y
+        END-IF
+        CALL "World-GetBlock" USING BLOCK-POSITION BLOCK-ID
+        CALL "Blocks-Get-StateDescription" USING BLOCK-ID OTHER-HALF-DESCRIPTION
+
+        *> Check if the block matches (normally there shouldn't be single-block doors, but just in case)
+        IF OTHER-HALF-NAME NOT = CLICKED-NAME
+            GOBACK
+        END-IF
+        CALL "Blocks-Description-GetValue" USING OTHER-HALF-DESCRIPTION C-HALF HALF-VALUE-OTHER
+        IF HALF-VALUE-CLICKED = HALF-VALUE-OTHER
+            GOBACK
+        END-IF
+
+        *> Toggle the "open" property for the other half
+        CALL "Blocks-Description-SetValue" USING OTHER-HALF-DESCRIPTION C-OPEN OPEN-VALUE
+        CALL "Blocks-Get-StateId" USING OTHER-HALF-DESCRIPTION BLOCK-ID
+        CALL "World-SetBlock" USING PLAYER-CLIENT(LK-PLAYER) BLOCK-POSITION BLOCK-ID
+
+        GOBACK.
+
+    END PROGRAM Callback-Interact.
+
+END PROGRAM RegisterBlock-Door.

--- a/src/items/bed.cob
+++ b/src/items/bed.cob
@@ -15,7 +15,7 @@ WORKING-STORAGE SECTION.
 PROCEDURE DIVISION.
     SET USE-PTR TO ENTRY "Callback-Use"
 
-    *> Loop over all blocks and register the callback for each button
+    *> Loop over all blocks and register the callback for each bed
     CALL "Blocks-GetCount" USING BLOCK-COUNT
     PERFORM VARYING BLOCK-INDEX FROM 1 BY 1 UNTIL BLOCK-INDEX > BLOCK-COUNT
         CALL "Blocks-Iterate-Type" USING BLOCK-INDEX BLOCK-TYPE

--- a/src/items/door.cob
+++ b/src/items/door.cob
@@ -1,0 +1,201 @@
+*> --- RegisterItem-Door ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterItem-Door.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 C-MINECRAFT-DOOR                 PIC X(32) GLOBAL    VALUE "minecraft:door".
+    01 USE-PTR                          PROGRAM-POINTER.
+    01 BLOCK-COUNT                      BINARY-LONG UNSIGNED.
+    01 BLOCK-INDEX                      BINARY-LONG UNSIGNED.
+    01 BLOCK-NAME                       PIC X(64).
+    01 BLOCK-TYPE                       PIC X(64).
+
+PROCEDURE DIVISION.
+    SET USE-PTR TO ENTRY "Callback-Use"
+
+    *> Loop over all blocks and register the callback for each door
+    CALL "Blocks-GetCount" USING BLOCK-COUNT
+    PERFORM VARYING BLOCK-INDEX FROM 1 BY 1 UNTIL BLOCK-INDEX > BLOCK-COUNT
+        CALL "Blocks-Iterate-Type" USING BLOCK-INDEX BLOCK-TYPE
+        IF BLOCK-TYPE = C-MINECRAFT-DOOR
+            CALL "Blocks-Iterate-Name" USING BLOCK-INDEX BLOCK-NAME
+            CALL "SetCallback-ItemUse" USING BLOCK-NAME USE-PTR
+        END-IF
+    END-PERFORM
+
+    GOBACK.
+
+    *> --- Callback-Use ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Use.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        COPY DD-PLAYERS.
+        01 C-FACING                 PIC X(6)                VALUE "facing".
+        01 C-HINGE                  PIC X(5)                VALUE "hinge".
+        01 C-HALF                   PIC X(4)                VALUE "half".
+        01 C-OPEN                   PIC X(4)                VALUE "open".
+        01 C-POWERED                PIC X(7)                VALUE "powered".
+        *> Block state description for the block to place.
+        COPY DD-BLOCK-STATE REPLACING LEADING ==PREFIX== BY ==PLACE==.
+        01 BLOCK-POSITION-LOWER.
+            02 BLOCK-X              BINARY-LONG.
+            02 BLOCK-Y              BINARY-LONG.
+            02 BLOCK-Z              BINARY-LONG.
+        01 BLOCK-POSITION-UPPER.
+            02 BLOCK-X              BINARY-LONG.
+            02 BLOCK-Y              BINARY-LONG.
+            02 BLOCK-Z              BINARY-LONG.
+        01 FACING                   PIC X(16).
+        01 HINGE                    PIC X(16).
+        01 BLOCK-ID                 BINARY-LONG.
+        *> Block state description for neighboring blocks.
+        COPY DD-BLOCK-STATE REPLACING LEADING ==PREFIX== BY ==NEIGHBOR==.
+        01 NEIGHBOR-LEFT-POSITION.
+            02 NEIGHBOR-LEFT-X      BINARY-LONG.
+            02 NEIGHBOR-LEFT-Y      BINARY-LONG.
+            02 NEIGHBOR-LEFT-Z      BINARY-LONG.
+        01 NEIGHBOR-RIGHT-POSITION.
+            02 NEIGHBOR-RIGHT-X     BINARY-LONG.
+            02 NEIGHBOR-RIGHT-Y     BINARY-LONG.
+            02 NEIGHBOR-RIGHT-Z     BINARY-LONG.
+        01 NEIGHBOR-FACING          PIC X(16).
+        01 NEIGHBOR-HINGE           PIC X(16).
+        01 NEIGHBOR-HALF            PIC X(16).
+        01 HAS-DOOR-LEFT            BINARY-CHAR UNSIGNED.
+        01 HAS-DOOR-RIGHT           BINARY-CHAR UNSIGNED.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-ITEM-USE.
+
+    PROCEDURE DIVISION USING LK-PLAYER LK-ITEM-NAME LK-POSITION LK-FACE LK-CURSOR.
+        *> TODO reduce duplication with other callbacks
+
+        *> Compute the position of the lower block
+        MOVE LK-POSITION TO BLOCK-POSITION-LOWER
+        CALL "Facing-GetRelative" USING LK-FACE BLOCK-POSITION-LOWER
+
+        MOVE LK-ITEM-NAME TO PLACE-NAME
+
+        MOVE 5 TO PLACE-PROPERTY-COUNT
+        *> facing, hinge: set depending on player facing and cursor position; half: set when placing the blocks
+        MOVE C-FACING TO PLACE-PROPERTY-NAME(1)
+        MOVE C-HINGE TO PLACE-PROPERTY-NAME(2)
+        MOVE C-HALF TO PLACE-PROPERTY-NAME(3)
+        *> open, powered: set to false
+        MOVE C-OPEN TO PLACE-PROPERTY-NAME(4)
+        MOVE "false" TO PLACE-PROPERTY-VALUE(4)
+        MOVE C-POWERED TO PLACE-PROPERTY-NAME(5)
+        MOVE "false" TO PLACE-PROPERTY-VALUE(5)
+
+        *> Use the player's yaw to determine the facing
+        EVALUATE FUNCTION MOD(PLAYER-YAW(LK-PLAYER) + 45, 360)
+            WHEN < 90
+                MOVE "south" TO FACING
+            WHEN < 180
+                MOVE "west" TO FACING
+            WHEN < 270
+                MOVE "north" TO FACING
+            WHEN OTHER
+                MOVE "east" TO FACING
+        END-EVALUATE
+
+        *> Use the click position to determine the hinge
+        EVALUATE TRUE
+            WHEN FACING = "north" AND LK-CURSOR-X < 0.5
+                MOVE "left" TO HINGE
+            WHEN FACING = "north"
+                MOVE "right" TO HINGE
+            WHEN FACING = "east" AND LK-CURSOR-Z < 0.5
+                MOVE "left" TO HINGE
+            WHEN FACING = "east"
+                MOVE "right" TO HINGE
+            WHEN FACING = "south" AND LK-CURSOR-X < 0.5
+                MOVE "right" TO HINGE
+            WHEN FACING = "south"
+                MOVE "left" TO HINGE
+            WHEN FACING = "west" AND LK-CURSOR-Z < 0.5
+                MOVE "right" TO HINGE
+            WHEN FACING = "west"
+                MOVE "left" TO HINGE
+        END-EVALUATE
+
+        *> Check for matching door blocks to the left and right
+        MOVE BLOCK-POSITION-LOWER TO NEIGHBOR-LEFT-POSITION
+        MOVE BLOCK-POSITION-LOWER TO NEIGHBOR-RIGHT-POSITION
+        EVALUATE FACING
+            WHEN "north"
+                ADD 1 TO NEIGHBOR-LEFT-X
+                SUBTRACT 1 FROM NEIGHBOR-RIGHT-X
+            WHEN "east"
+                SUBTRACT 1 FROM NEIGHBOR-LEFT-Z
+                ADD 1 TO NEIGHBOR-RIGHT-Z
+            WHEN "south"
+                SUBTRACT 1 FROM NEIGHBOR-LEFT-X
+                ADD 1 TO NEIGHBOR-RIGHT-X
+            WHEN "west"
+                ADD 1 TO NEIGHBOR-LEFT-Z
+                SUBTRACT 1 FROM NEIGHBOR-RIGHT-Z
+        END-EVALUATE
+        *> left
+        CALL "World-GetBlock" USING NEIGHBOR-LEFT-POSITION BLOCK-ID
+        CALL "Blocks-Get-StateDescription" USING BLOCK-ID NEIGHBOR-DESCRIPTION
+        MOVE 0 TO HAS-DOOR-LEFT
+        IF NEIGHBOR-NAME = PLACE-NAME
+            CALL "Blocks-Description-GetValue" USING NEIGHBOR-DESCRIPTION C-FACING NEIGHBOR-FACING
+            CALL "Blocks-Description-GetValue" USING NEIGHBOR-DESCRIPTION C-HINGE NEIGHBOR-HINGE
+            CALL "Blocks-Description-GetValue" USING NEIGHBOR-DESCRIPTION C-HALF NEIGHBOR-HALF
+            IF NEIGHBOR-FACING = FACING AND NEIGHBOR-HINGE = "left" AND NEIGHBOR-HALF = "lower"
+                MOVE 1 TO HAS-DOOR-LEFT
+            END-IF
+        END-IF
+        *> right
+        CALL "World-GetBlock" USING NEIGHBOR-RIGHT-POSITION BLOCK-ID
+        CALL "Blocks-Get-StateDescription" USING BLOCK-ID NEIGHBOR-DESCRIPTION
+        MOVE 0 TO HAS-DOOR-RIGHT
+        IF NEIGHBOR-NAME = PLACE-NAME
+            CALL "Blocks-Description-GetValue" USING NEIGHBOR-DESCRIPTION C-FACING NEIGHBOR-FACING
+            CALL "Blocks-Description-GetValue" USING NEIGHBOR-DESCRIPTION C-HINGE NEIGHBOR-HINGE
+            CALL "Blocks-Description-GetValue" USING NEIGHBOR-DESCRIPTION C-HALF NEIGHBOR-HALF
+            IF NEIGHBOR-FACING = FACING AND NEIGHBOR-HINGE = "right" AND NEIGHBOR-HALF = "lower"
+                MOVE 1 TO HAS-DOOR-RIGHT
+            END-IF
+        END-IF
+
+        *> The hinge may switch sides in case there is a door on the other side, but not on the current side.
+        EVALUATE TRUE
+            WHEN HINGE = "left" AND HAS-DOOR-LEFT = 1 AND HAS-DOOR-RIGHT = 0
+                MOVE "right" TO HINGE
+            WHEN HINGE = "right" AND HAS-DOOR-LEFT = 0 AND HAS-DOOR-RIGHT = 1
+                MOVE "left" TO HINGE
+        END-EVALUATE
+
+        MOVE FACING TO PLACE-PROPERTY-VALUE(1)
+        MOVE HINGE TO PLACE-PROPERTY-VALUE(2)
+
+        *> Compute the position of the upper block
+        MOVE BLOCK-POSITION-LOWER TO BLOCK-POSITION-UPPER
+        ADD 1 TO BLOCK-Y OF BLOCK-POSITION-UPPER
+
+        *> Ensure both blocks are air
+        CALL "World-GetBlock" USING BLOCK-POSITION-LOWER BLOCK-ID
+        IF BLOCK-ID NOT = 0 GOBACK.
+        CALL "World-GetBlock" USING BLOCK-POSITION-UPPER BLOCK-ID
+        IF BLOCK-ID NOT = 0 GOBACK.
+
+        *> TODO check for solid block below
+
+        *> Place the door
+        MOVE "lower" TO PLACE-PROPERTY-VALUE(3)
+        CALL "Blocks-Get-StateId" USING PLACE-DESCRIPTION BLOCK-ID
+        CALL "World-SetBlock" USING PLAYER-CLIENT(LK-PLAYER) BLOCK-POSITION-LOWER BLOCK-ID
+        MOVE "upper" TO PLACE-PROPERTY-VALUE(3)
+        CALL "Blocks-Get-StateId" USING PLACE-DESCRIPTION BLOCK-ID
+        CALL "World-SetBlock" USING PLAYER-CLIENT(LK-PLAYER) BLOCK-POSITION-UPPER BLOCK-ID
+
+        GOBACK.
+
+    END PROGRAM Callback-Use.
+
+END PROGRAM RegisterItem-Door.

--- a/src/server.cob
+++ b/src/server.cob
@@ -141,6 +141,7 @@ RegisterItems.
     CALL "RegisterItem-Slab"
     CALL "RegisterItem-RotatedPillar"
     CALL "RegisterItem-Button"
+    CALL "RegisterItem-Door"
     CALL "RegisterItem-Trapdoor"
     CALL "RegisterItem-Bed"
     .
@@ -149,6 +150,7 @@ RegisterBlocks.
     DISPLAY "Registering blocks"
 
     *> Register blocks with special handling
+    CALL "RegisterBlock-Door"
     CALL "RegisterBlock-Trapdoor"
     .
 


### PR DESCRIPTION
Doors are now properly oriented when placed. This includes taking into account any existing doors of the same type next to the one being placed, forming double doors.

An interaction callback is also added for opening and closing the doors when right-clicked by a player.