### PR TITLE
feat: Add support for buckets (water, lava, empty)

### DIFF
--- a/src/items/bucket.cob
+++ b/src/items/bucket.cob
@@ -1,0 +1,65 @@
+*> --- RegisterItem-Bucket ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterItem-Bucket.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 C-MINECRAFT-BUCKET               PIC X(32) GLOBAL    VALUE "minecraft:bucket".
+    01 C-MINECRAFT-WATER                PIC X(32) GLOBAL    VALUE "minecraft:water".
+    01 C-MINECRAFT-LAVA                 PIC X(32) GLOBAL    VALUE "minecraft:lava".
+    01 C-MINECRAFT-AIR                  PIC X(32) GLOBAL    VALUE "minecraft:air".
+    01 USE-PTR                          PROGRAM-POINTER.
+    01 BLOCK-COUNT                      BINARY-LONG UNSIGNED.
+    01 BLOCK-INDEX                      BINARY-LONG UNSIGNED.
+    01 BLOCK-NAME                       PIC X(64).
+    01 BLOCK-TYPE                       PIC X(64).
+
+PROCEDURE DIVISION.
+    SET USE-PTR TO ENTRY "Callback-Use"
+    CALL "SetCallback-ItemUse" USING C-MINECRAFT-BUCKET USE-PTR
+    GOBACK.
+
+    *> --- Callback-Use ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Use.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        01 C-LEVEL                  PIC X(5)                VALUE "level".
+        01 BLOCK-POSITION.
+            02 BLOCK-X              BINARY-LONG.
+            02 BLOCK-Y              BINARY-LONG.
+            02 BLOCK-Z              BINARY-LONG.
+        *> Block state description for the block currently in the world.
+        COPY DD-BLOCK-STATE REPLACING LEADING ==PREFIX== BY ==CURRENT==.
+        01 FLUID-LEVEL              PIC X(32).
+        01 BLOCK-ID                 BINARY-LONG.
+        COPY DD-PLAYERS.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-ITEM-USE.
+
+    PROCEDURE DIVISION USING LK-PLAYER LK-ITEM-NAME LK-POSITION LK-FACE LK-CURSOR.
+        MOVE LK-POSITION TO BLOCK-POSITION
+        CALL "World-GetBlock" USING BLOCK-POSITION BLOCK-ID
+        CALL "Facing-GetRelative" USING LK-FACE BLOCK-POSITION
+
+        *> Allow replacing water or lava source blocks (fluid level 0)
+        CALL "World-GetBlock" USING BLOCK-POSITION BLOCK-ID
+        CALL "Blocks-Get-StateDescription" USING BLOCK-ID CURRENT-DESCRIPTION
+        IF CURRENT-NAME NOT = C-MINECRAFT-WATER AND CURRENT-NAME NOT = C-MINECRAFT-LAVA
+            GOBACK
+        END-IF
+        CALL "Blocks-Description-GetValue" USING CURRENT-DESCRIPTION C-LEVEL FLUID-LEVEL
+        IF FLUID-LEVEL NOT = "0"
+            GOBACK
+        END-IF
+
+        *> Place air
+        CALL "Blocks-Get-DefaultStateId" USING C-MINECRAFT-AIR BLOCK-ID
+        CALL "World-SetBlock" USING PLAYER-CLIENT(LK-PLAYER) BLOCK-POSITION BLOCK-ID
+
+        GOBACK.
+
+    END PROGRAM Callback-Use.
+
+END PROGRAM RegisterItem-Bucket.

--- a/src/items/lava-bucket.cob
+++ b/src/items/lava-bucket.cob
@@ -1,0 +1,61 @@
+*> --- RegisterItem-LavaBucket ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterItem-LavaBucket.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 C-MINECRAFT-LAVA_BUCKET          PIC X(32) GLOBAL    VALUE "minecraft:lava_bucket".
+    01 C-MINECRAFT-WATER                PIC X(32) GLOBAL    VALUE "minecraft:water".
+    01 C-MINECRAFT-LAVA                 PIC X(32) GLOBAL    VALUE "minecraft:lava".
+    01 C-MINECRAFT-AIR                  PIC X(32) GLOBAL    VALUE "minecraft:air".
+    01 USE-PTR                          PROGRAM-POINTER.
+    01 BLOCK-COUNT                      BINARY-LONG UNSIGNED.
+    01 BLOCK-INDEX                      BINARY-LONG UNSIGNED.
+    01 BLOCK-NAME                       PIC X(64).
+    01 BLOCK-TYPE                       PIC X(64).
+
+PROCEDURE DIVISION.
+    SET USE-PTR TO ENTRY "Callback-Use"
+    CALL "SetCallback-ItemUse" USING C-MINECRAFT-LAVA_BUCKET USE-PTR
+    GOBACK.
+
+    *> --- Callback-Use ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Use.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        01 BLOCK-POSITION.
+            02 BLOCK-X              BINARY-LONG.
+            02 BLOCK-Y              BINARY-LONG.
+            02 BLOCK-Z              BINARY-LONG.
+        *> Block state description for the block currently in the world.
+        COPY DD-BLOCK-STATE REPLACING LEADING ==PREFIX== BY ==CURRENT==.
+        01 BLOCK-ID                 BINARY-LONG.
+        COPY DD-PLAYERS.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-ITEM-USE.
+
+    PROCEDURE DIVISION USING LK-PLAYER LK-ITEM-NAME LK-POSITION LK-FACE LK-CURSOR.
+        *> Compute the position of the block to be affected
+        MOVE LK-POSITION TO BLOCK-POSITION
+        CALL "Facing-GetRelative" USING LK-FACE BLOCK-POSITION
+
+        *> TODO allow replacing some blocks other than air (grass, etc.)
+
+        *> Allow replacing air, water, or lava
+        CALL "World-GetBlock" USING BLOCK-POSITION BLOCK-ID
+        CALL "Blocks-Get-StateDescription" USING BLOCK-ID CURRENT-DESCRIPTION
+        IF CURRENT-NAME NOT = C-MINECRAFT-AIR AND CURRENT-NAME NOT = C-MINECRAFT-WATER AND CURRENT-NAME NOT = C-MINECRAFT-LAVA
+            GOBACK
+        END-IF
+
+        *> Place lava
+        CALL "Blocks-Get-DefaultStateId" USING C-MINECRAFT-LAVA BLOCK-ID
+        CALL "World-SetBlock" USING PLAYER-CLIENT(LK-PLAYER) BLOCK-POSITION BLOCK-ID
+
+        GOBACK.
+
+    END PROGRAM Callback-Use.
+
+END PROGRAM RegisterItem-LavaBucket.

--- a/src/items/water-bucket.cob
+++ b/src/items/water-bucket.cob
@@ -1,0 +1,62 @@
+*> --- RegisterItem-WaterBucket ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterItem-WaterBucket.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 C-MINECRAFT-WATER_BUCKET         PIC X(32) GLOBAL    VALUE "minecraft:water_bucket".
+    01 C-MINECRAFT-WATER                PIC X(32) GLOBAL    VALUE "minecraft:water".
+    01 C-MINECRAFT-LAVA                 PIC X(32) GLOBAL    VALUE "minecraft:lava".
+    01 C-MINECRAFT-AIR                  PIC X(32) GLOBAL    VALUE "minecraft:air".
+    01 USE-PTR                          PROGRAM-POINTER.
+    01 BLOCK-COUNT                      BINARY-LONG UNSIGNED.
+    01 BLOCK-INDEX                      BINARY-LONG UNSIGNED.
+    01 BLOCK-NAME                       PIC X(64).
+    01 BLOCK-TYPE                       PIC X(64).
+
+PROCEDURE DIVISION.
+    SET USE-PTR TO ENTRY "Callback-Use"
+    CALL "SetCallback-ItemUse" USING C-MINECRAFT-WATER_BUCKET USE-PTR
+    GOBACK.
+
+    *> --- Callback-Use ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Use.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        01 BLOCK-POSITION.
+            02 BLOCK-X              BINARY-LONG.
+            02 BLOCK-Y              BINARY-LONG.
+            02 BLOCK-Z              BINARY-LONG.
+        *> Block state description for the block currently in the world.
+        COPY DD-BLOCK-STATE REPLACING LEADING ==PREFIX== BY ==CURRENT==.
+        01 BLOCK-ID                 BINARY-LONG.
+        COPY DD-PLAYERS.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-ITEM-USE.
+
+    PROCEDURE DIVISION USING LK-PLAYER LK-ITEM-NAME LK-POSITION LK-FACE LK-CURSOR.
+        *> Compute the position of the block to be affected
+        MOVE LK-POSITION TO BLOCK-POSITION
+        CALL "Facing-GetRelative" USING LK-FACE BLOCK-POSITION
+
+        *> TODO allow replacing some blocks other than air (grass, etc.)
+        *> TODO implement waterlogging
+
+        *> Allow replacing air, water, or lava
+        CALL "World-GetBlock" USING BLOCK-POSITION BLOCK-ID
+        CALL "Blocks-Get-StateDescription" USING BLOCK-ID CURRENT-DESCRIPTION
+        IF CURRENT-NAME NOT = C-MINECRAFT-AIR AND CURRENT-NAME NOT = C-MINECRAFT-WATER AND CURRENT-NAME NOT = C-MINECRAFT-LAVA
+            GOBACK
+        END-IF
+
+        *> Place water
+        CALL "Blocks-Get-DefaultStateId" USING C-MINECRAFT-WATER BLOCK-ID
+        CALL "World-SetBlock" USING PLAYER-CLIENT(LK-PLAYER) BLOCK-POSITION BLOCK-ID
+
+        GOBACK.
+
+    END PROGRAM Callback-Use.
+
+END PROGRAM RegisterItem-WaterBucket.

--- a/src/server.cob
+++ b/src/server.cob
@@ -151,6 +151,9 @@ RegisterItems.
     CALL "RegisterItem-Door"
     CALL "RegisterItem-Trapdoor"
     CALL "RegisterItem-Bed"
+    CALL "RegisterItem-Bucket"
+    CALL "RegisterItem-WaterBucket"
+    CALL "RegisterItem-LavaBucket"
     .
 
 RegisterBlocks.
@@ -1098,6 +1101,33 @@ HandlePlay SECTION.
                 WHEN CALLBACK-PTR-BLOCK NOT = NULL
                     CALL CALLBACK-PTR-BLOCK USING CLIENT-PLAYER(CLIENT-ID) TEMP-IDENTIFIER TEMP-POSITION TEMP-BLOCK-FACE TEMP-CURSOR
             END-EVALUATE
+
+            *> Acknowledge the action
+            CALL "SendPacket-AckBlockChange" USING CLIENT-ID SEQUENCE-ID
+
+        *> Use item
+        WHEN H'39'
+            *> hand enum: 0=main hand, 1=off hand
+            CALL "Decode-VarInt" USING PACKET-BUFFER(CLIENT-ID) PACKET-POSITION TEMP-INT32
+            IF TEMP-INT32 = 0
+                *> compute the inventory slot
+                COMPUTE TEMP-INT16 = 36 + PLAYER-HOTBAR(CLIENT-PLAYER(CLIENT-ID))
+            ELSE
+                MOVE 45 TO TEMP-INT16
+            END-IF
+
+            *> sequence ID
+            CALL "Decode-VarInt" USING PACKET-BUFFER(CLIENT-ID) PACKET-POSITION SEQUENCE-ID
+
+            *> TODO: Buckets send this packet when clicking a liquid directly - handle this case
+            *> TODO food items
+            *> TODO potions
+            *> TODO splash potions
+            *> TODO lingering potions
+            *> TODO bows
+            *> TODO shields
+            *> TODO bottle o' enchanting
+            *> TODO eggs, snowballs, ender pearls, etc.
 
             *> Acknowledge the action
             CALL "SendPacket-AckBlockChange" USING CLIENT-ID SEQUENCE-ID


### PR DESCRIPTION
This patch adds support for the main bucket types, allowing players to place and remove water and lava source blocks. This is rather straight-forward for the most part, as long as the player is clicking on a non-fluid block to place or remove a fluid next to it. However, the player may also be far enough away such that they are not in reach of any such block, but would be in reach of an existing fluid block. This scenario does NOT trigger a "use item on" packet to be sent. Instead, the client sends a "use item" packet as if the player was clicking in air, while still expecting the server to calculate the liquid block as the click target and act on it. This requires ray-tracing to be implemented on the server, which is not on my agenda, yet. Hence, this patch simply acknowledges the "use item" action without updating any blocks, thereby preventing direct interactions with fluid blocks to avoid desynchronization issues.