### PR TITLE
fix: Obtain dimension_type and chat_type from registry

### DIFF
--- a/src/packets/login-play.cob
+++ b/src/packets/login-play.cob
@@ -3,21 +3,22 @@ PROGRAM-ID. SendPacket-LoginPlay.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID                BINARY-LONG             VALUE H'2B'.
+    01 PACKET-ID                    BINARY-LONG                 VALUE H'2B'.
     *> constants
-    01 C-MINECRAFT-OVERWORLD    PIC X(19) VALUE "minecraft:overworld".
+    01 C-MINECRAFT-DIMENSION_TYPE   PIC X(24)                   VALUE "minecraft:dimension_type".
+    01 C-MINECRAFT-OVERWORLD        PIC X(19)                   VALUE "minecraft:overworld".
     *> temporary data used during encoding
-    01 INT32                    BINARY-LONG.
+    01 INT32                        BINARY-LONG.
     *> buffer used to store the packet data
-    01 PAYLOAD                  PIC X(64000).
-    01 PAYLOADPOS               BINARY-LONG UNSIGNED.
-    01 PAYLOADLEN               BINARY-LONG UNSIGNED.
+    01 PAYLOAD                      PIC X(64000).
+    01 PAYLOADPOS                   BINARY-LONG UNSIGNED.
+    01 PAYLOADLEN                   BINARY-LONG UNSIGNED.
 LINKAGE SECTION.
-    01 LK-CLIENT                BINARY-LONG UNSIGNED.
-    01 LK-ENTITY-ID             BINARY-LONG.
-    01 LK-VIEW-DISTANCE         BINARY-LONG.
-    01 LK-GAMEMODE              BINARY-CHAR UNSIGNED.
-    01 LK-MAX-PLAYERS           BINARY-LONG.
+    01 LK-CLIENT                    BINARY-LONG UNSIGNED.
+    01 LK-ENTITY-ID                 BINARY-LONG.
+    01 LK-VIEW-DISTANCE             BINARY-LONG.
+    01 LK-GAMEMODE                  BINARY-CHAR UNSIGNED.
+    01 LK-MAX-PLAYERS               BINARY-LONG.
 
 PROCEDURE DIVISION USING LK-CLIENT LK-ENTITY-ID LK-VIEW-DISTANCE LK-GAMEMODE LK-MAX-PLAYERS.
     MOVE 1 TO PAYLOADPOS
@@ -59,8 +60,7 @@ PROCEDURE DIVISION USING LK-CLIENT LK-ENTITY-ID LK-VIEW-DISTANCE LK-GAMEMODE LK-
     ADD 1 TO PAYLOADPOS
 
     *> dimension type (ID in the minecraft:dimension_type registry)
-    *> TODO: get this from the registry
-    MOVE 0 TO INT32
+    CALL "Registries-Get-EntryId" USING C-MINECRAFT-DIMENSION_TYPE C-MINECRAFT-OVERWORLD INT32
     CALL "Encode-VarInt" USING INT32 PAYLOAD PAYLOADPOS
 
     *> dimension name="minecraft:overworld"

--- a/src/packets/player-chat.cob
+++ b/src/packets/player-chat.cob
@@ -3,20 +3,22 @@ PROGRAM-ID. SendPacket-PlayerChat.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
-    01 PACKET-ID        BINARY-LONG             VALUE H'39'.
+    01 PACKET-ID                    BINARY-LONG                 VALUE H'39'.
+    01 C-MINECRAFT-CHAT_TYPE        PIC X(19)                   VALUE "minecraft:chat_type".
+    01 C-MINECRAFT-CHAT             PIC X(14)                   VALUE "minecraft:chat".
     *> temporary data used during encoding
-    01 UINT16           BINARY-SHORT UNSIGNED.
-    01 INT32            BINARY-LONG.
+    01 UINT16                       BINARY-LONG-LONG UNSIGNED.
+    01 INT32                        BINARY-LONG.
     *> buffer used to store the packet data
-    01 PAYLOAD          PIC X(64000).
-    01 PAYLOADPOS       BINARY-LONG UNSIGNED.
-    01 PAYLOADLEN       BINARY-LONG UNSIGNED.
+    01 PAYLOAD                      PIC X(64000).
+    01 PAYLOADPOS                   BINARY-LONG UNSIGNED.
+    01 PAYLOADLEN                   BINARY-LONG UNSIGNED.
 LINKAGE SECTION.
-    01 LK-CLIENT        BINARY-LONG UNSIGNED.
-    01 LK-SENDER-UUID   PIC X(16).
-    01 LK-SENDER-NAME   PIC X ANY LENGTH.
-    01 LK-MESSAGE       PIC X ANY LENGTH.
-    01 LK-MESSAGE-LEN   BINARY-LONG UNSIGNED.
+    01 LK-CLIENT                    BINARY-LONG UNSIGNED.
+    01 LK-SENDER-UUID               PIC X(16).
+    01 LK-SENDER-NAME               PIC X ANY LENGTH.
+    01 LK-MESSAGE                   PIC X ANY LENGTH.
+    01 LK-MESSAGE-LEN               BINARY-LONG UNSIGNED.
 
 PROCEDURE DIVISION USING LK-CLIENT LK-SENDER-UUID LK-SENDER-NAME LK-MESSAGE LK-MESSAGE-LEN.
     MOVE 1 TO PAYLOADPOS
@@ -63,9 +65,9 @@ PROCEDURE DIVISION USING LK-CLIENT LK-SENDER-UUID LK-SENDER-NAME LK-MESSAGE LK-M
     *> --- chat formatting ---
 
     *> chat type
-    *> TODO: This is a reference to the "minecraft:chat_type" registry. Get the correct value from the registry.
-    MOVE X"01" TO PAYLOAD(PAYLOADPOS:1)
-    ADD 1 TO PAYLOADPOS
+    CALL "Registries-Get-EntryId" USING C-MINECRAFT-CHAT_TYPE C-MINECRAFT-CHAT INT32
+    ADD 1 TO INT32
+    CALL "Encode-VarInt" USING INT32 PAYLOAD PAYLOADPOS
 
     *> sender name (NBT string tag)
     MOVE X"08" TO PAYLOAD(PAYLOADPOS:1)


### PR DESCRIPTION
Continuation of #195 to make use of the data that is now available for chat and dimension types.

Note: For some reason, the chat type needs 1 added to it. This was already the case when using the blob, however. It seems to have changed between 1.20.6 and 1.21. Should keep an eye on this packet.