### PR TITLE
feat: Add a persistent JSON file-based whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.DS_Store
 .idea
+.vscode
 *.so
 /out
 /cobolcraft
@@ -6,3 +8,4 @@
 /test
 /test.log
 /save
+/whitelist.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following features are already working:
 - [X] player inventory (limited to creative mode)
 - [X] chat
 - [X] commands (in-game and via an interactive console)
-- [X] whitelist (single player, edit `main.cob` to enable/set username)
+- [X] whitelist (persistent; stored in `whitelist.json`)
 
 Note that blocks with multiple states, orientations, or interactive blocks require large amounts of specialized code
 to make them behave properly, which is way beyond the scope of this project.

--- a/main.cob
+++ b/main.cob
@@ -5,8 +5,8 @@ DATA DIVISION.
 WORKING-STORAGE SECTION.
     01 SERVER-CONFIG.
         02 PORT                 PIC X(5)    VALUE "25565".
+        *> To configure the whitelist, use console/in-game commands or edit whitelist.json.
         02 WHITELIST-ENABLE     BINARY-CHAR VALUE 0.
-        02 WHITELIST-PLAYER     PIC X(16)   VALUE "Notch".
         02 MOTD                 PIC X(64)   VALUE "CobolCraft".
 
 PROCEDURE DIVISION.

--- a/src/copybooks/DD-WHITELIST.cpy
+++ b/src/copybooks/DD-WHITELIST.cpy
@@ -1,0 +1,10 @@
+*> --- Copybook: shared data for the player whitelist ---
+
+*> The maximum number of players that can be whitelisted.
+78 MAX-WHITELIST-LENGTH VALUE 100.
+
+01 WHITELIST EXTERNAL.
+    02 WHITELIST-LENGTH BINARY-LONG UNSIGNED.
+    02 WHITELIST-ENTRY OCCURS MAX-WHITELIST-LENGTH TIMES.
+        03 WHITELIST-NAME PIC X(16).
+        03 WHITELIST-UUID PIC X(16).


### PR DESCRIPTION
The whitelist can now support up to 100 players. It is stored in a whitelist.json file in the server directory, using the same format as the official server to be drop-in compatible.

Console and in-game commands are also added to reload the whitelist, list whitelisted players, and add/remove players.