### PR TITLE
feat: Use server.properties for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /test
 /test.log
 /save
+/server.properties
 /whitelist.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The following features are already working:
 - [X] player inventory (limited to creative mode)
 - [X] chat
 - [X] commands (in-game and via an interactive console)
-- [X] whitelist (persistent; stored in `whitelist.json`)
+- [X] configuration via server.properties
+- [X] whitelist (persistent; stored in whitelist.json)
 
 Note that blocks with multiple states, orientations, or interactive blocks require large amounts of specialized code
 to make them behave properly, which is way beyond the scope of this project.
@@ -55,17 +56,27 @@ Or, using Docker:
 
 ```sh
 docker build -t cobolcraft .
-docker run --rm -p 25565:25565 -it cobolcraft
+docker run --rm --interactive --tty \
+     --publish 25565:25565 \
+     --volume server.properties:/server.properties \
+     --volume whitelist.json:/whitelist.json \
+     --volume save:/save \
+    cobolcraft
 ```
 
-To configure the server, edit the variables in `main.cob` (limited options available).
+To configure the server, edit the `server.properties` file.
+This file is generated automatically on first run with default values for all supported options:
+
+* `server-port` (default: 25565)
+* `white-list` (default: false)
+* `motd` (default: "CobolCraft")
 
 Note: By default, the server is only accessible via localhost (i.e., only on your own system via `localhost:25565`).
 To make it accessible from the outside (your local network, via VPN, port forwarding, on a rented server, ...), you
 can start the Docker container like this:
 
 ```sh
-docker run --rm -p 0.0.0.0:25565:25565 -it cobolcraft
+docker run --rm -it -p 0.0.0.0:25565:25565 cobolcraft
 ```
 
 ## Why?

--- a/main.cob
+++ b/main.cob
@@ -1,15 +1,9 @@
 IDENTIFICATION DIVISION.
 PROGRAM-ID. Main.
 
-DATA DIVISION.
-WORKING-STORAGE SECTION.
-    01 SERVER-CONFIG.
-        02 PORT                 PIC X(5)    VALUE "25565".
-        *> To configure the whitelist, use console/in-game commands or edit whitelist.json.
-        02 WHITELIST-ENABLE     BINARY-CHAR VALUE 0.
-        02 MOTD                 PIC X(64)   VALUE "CobolCraft".
-
 PROCEDURE DIVISION.
-    CALL "Server" USING SERVER-CONFIG.
+    *> To edit the configuration, run the server once ("make run") and then edit the
+    *> generated server.properties file.
+    CALL "Server".
 
 END PROGRAM Main.

--- a/src/copybooks/DD-SERVER-PROPERTIES.cpy
+++ b/src/copybooks/DD-SERVER-PROPERTIES.cpy
@@ -1,0 +1,6 @@
+*> --- Copybook: shared data for server.properties ---
+
+01 SERVER-PROPERTIES EXTERNAL.
+    02 SP-PORT                  PIC X(5).
+    02 SP-WHITELIST-ENABLE      BINARY-CHAR UNSIGNED.
+    02 SP-MOTD                  PIC X(64).

--- a/src/server-properties.cob
+++ b/src/server-properties.cob
@@ -1,0 +1,183 @@
+*> --- ServerProperties-Read ---
+*> Read the server.properties file. Default values are used if the file is not found or keys are missing.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. ServerProperties-Read.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    *> constants
+    01 SERVER-PROPERTIES-FILE   PIC X(32)                   VALUE "server.properties".
+    01 NEWLINE                  PIC X                       VALUE X"0A".
+    *> shared data
+    COPY DD-SERVER-PROPERTIES.
+    *> file buffer
+    01 READ-FAILURE             BINARY-CHAR UNSIGNED.
+    01 BUFFER                   PIC X(64000).
+    01 BUFFER-LENGTH            BINARY-LONG UNSIGNED.
+    *> parser state
+    01 BUFFER-POS               BINARY-LONG UNSIGNED.
+    01 ENTRY-OFFSET             BINARY-LONG UNSIGNED.
+    01 ENTRY-KEY                PIC X(255).
+    01 ENTRY-VALUE              PIC X(255).
+LINKAGE SECTION.
+    01 LK-FAILURE               BINARY-CHAR UNSIGNED.
+
+PROCEDURE DIVISION USING LK-FAILURE.
+    *> Start with default values
+    MOVE "25565" TO SP-PORT
+    MOVE 0 TO SP-WHITELIST-ENABLE
+    MOVE "CobolCraft" TO SP-MOTD
+
+    *> Attempt to read file, but ignore if missing
+    CALL "Files-ReadAll" USING SERVER-PROPERTIES-FILE BUFFER BUFFER-LENGTH READ-FAILURE
+    IF READ-FAILURE NOT = 0
+        GOBACK
+    END-IF
+
+    PERFORM VARYING BUFFER-POS FROM 1 BY 1 UNTIL BUFFER-POS > BUFFER-LENGTH
+        EVALUATE BUFFER(BUFFER-POS:1)
+            WHEN "#"
+                *> skip to the end of the line
+                PERFORM UNTIL BUFFER-POS >= BUFFER-LENGTH
+                    ADD 1 TO BUFFER-POS
+                    IF BUFFER(BUFFER-POS:1) = NEWLINE
+                        EXIT PERFORM
+                    END-IF
+                END-PERFORM
+
+            WHEN X"0A"
+                *> skip empty lines
+                CONTINUE
+
+            WHEN OTHER
+                *> read key
+                INITIALIZE ENTRY-KEY
+                MOVE 1 TO ENTRY-OFFSET
+                PERFORM UNTIL BUFFER-POS > BUFFER-LENGTH
+                    IF BUFFER(BUFFER-POS:1) = "=" OR BUFFER(BUFFER-POS:1) = " " OR BUFFER(BUFFER-POS:1) = NEWLINE
+                        EXIT PERFORM
+                    END-IF
+                    MOVE BUFFER(BUFFER-POS:1) TO ENTRY-KEY(ENTRY-OFFSET:1)
+                    ADD 1 TO BUFFER-POS
+                    ADD 1 TO ENTRY-OFFSET
+                END-PERFORM
+
+                *> TODO handle key longer than 255 characters
+                *> TODO handle multiple equals signs
+
+                *> skip spaces and the equals sign
+                PERFORM UNTIL BUFFER-POS > BUFFER-LENGTH
+                    IF BUFFER(BUFFER-POS:1) NOT = " " AND BUFFER(BUFFER-POS:1) NOT = "="
+                        EXIT PERFORM
+                    END-IF
+                    ADD 1 TO BUFFER-POS
+                END-PERFORM
+
+                *> read value
+                INITIALIZE ENTRY-VALUE
+                MOVE 1 TO ENTRY-OFFSET
+                PERFORM UNTIL BUFFER-POS > BUFFER-LENGTH
+                    IF BUFFER(BUFFER-POS:1) = NEWLINE
+                        EXIT PERFORM
+                    END-IF
+                    MOVE BUFFER(BUFFER-POS:1) TO ENTRY-VALUE(ENTRY-OFFSET:1)
+                    ADD 1 TO BUFFER-POS
+                    ADD 1 TO ENTRY-OFFSET
+                END-PERFORM
+
+                EVALUATE ENTRY-KEY
+                    WHEN "server-port"
+                        MOVE FUNCTION TRIM(ENTRY-VALUE) TO SP-PORT
+                        IF SP-PORT IS NOT NUMERIC
+                            MOVE 1 TO LK-FAILURE
+                            GOBACK
+                        END-IF
+
+                    WHEN "white-list"
+                        IF ENTRY-VALUE = "true"
+                            MOVE 1 TO SP-WHITELIST-ENABLE
+                        ELSE
+                            MOVE 0 TO SP-WHITELIST-ENABLE
+                        END-IF
+
+                    WHEN "motd"
+                        MOVE FUNCTION TRIM(ENTRY-VALUE) TO SP-MOTD
+                END-EVALUATE
+        END-EVALUATE
+    END-PERFORM
+
+    GOBACK.
+
+END PROGRAM ServerProperties-Read.
+
+*> --- ServerProperties-Write ---
+*> Write the server.properties file.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. ServerProperties-Write.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    *> constants
+    01 SERVER-PROPERTIES-FILE   PIC X(32)                   VALUE "server.properties".
+    01 NEWLINE                  PIC X                       VALUE X"0A".
+    *> shared data
+    COPY DD-SERVER-PROPERTIES.
+    *> file buffer
+    01 BUFFER                   PIC X(64000).
+    01 BUFFER-LENGTH            BINARY-LONG UNSIGNED.
+    *> temporary data
+    01 ENTRY-KEY                PIC X(255).
+    01 ENTRY-VALUE              PIC X(255).
+    01 BYTE-COUNT               BINARY-LONG UNSIGNED.
+LINKAGE SECTION.
+    01 LK-FAILURE               BINARY-CHAR UNSIGNED.
+
+PROCEDURE DIVISION USING LK-FAILURE.
+    MOVE "#CobolCraft server properties" TO BUFFER
+    MOVE FUNCTION STORED-CHAR-LENGTH(BUFFER) TO BUFFER-LENGTH
+
+    PERFORM AppendNewline
+
+    MOVE "server-port" TO ENTRY-KEY
+    MOVE SP-PORT TO ENTRY-VALUE
+    PERFORM AppendKeyValue
+
+    MOVE "white-list" TO ENTRY-KEY
+    IF SP-WHITELIST-ENABLE = 1
+        MOVE "true" TO ENTRY-VALUE
+    ELSE
+        MOVE "false" TO ENTRY-VALUE
+    END-IF
+    PERFORM AppendKeyValue
+
+    MOVE "motd" TO ENTRY-KEY
+    MOVE SP-MOTD TO ENTRY-VALUE
+    PERFORM AppendKeyValue
+
+    CALL "Files-WriteAll" USING SERVER-PROPERTIES-FILE BUFFER BUFFER-LENGTH LK-FAILURE
+
+    GOBACK.
+
+AppendKeyValue SECTION.
+    MOVE FUNCTION STORED-CHAR-LENGTH(ENTRY-KEY) TO BYTE-COUNT
+    MOVE ENTRY-KEY TO BUFFER(BUFFER-LENGTH + 1:BYTE-COUNT)
+    ADD BYTE-COUNT TO BUFFER-LENGTH
+
+    MOVE "=" TO BUFFER(BUFFER-LENGTH + 1:1)
+    ADD 1 TO BUFFER-LENGTH
+
+    MOVE FUNCTION STORED-CHAR-LENGTH(ENTRY-VALUE) TO BYTE-COUNT
+    MOVE ENTRY-VALUE TO BUFFER(BUFFER-LENGTH + 1:BYTE-COUNT)
+    ADD BYTE-COUNT TO BUFFER-LENGTH
+
+    PERFORM AppendNewline
+
+    EXIT SECTION.
+
+AppendNewline SECTION.
+    MOVE NEWLINE TO BUFFER(BUFFER-LENGTH + 1:1)
+    ADD 1 TO BUFFER-LENGTH
+
+    EXIT SECTION.
+
+END PROGRAM ServerProperties-Write.


### PR DESCRIPTION
This patch moves away from hardcoding the server configuration in main.cob before compilation, and towards the `server.properties` file also used by the official server.

So far, the parser is rather crude, but works for all supported options (server-port, white-list, motd - basically, everything that was supported before).