### PR TITLE
refactor: Split commands into files and make registerable

### DIFF
--- a/src/chat.cob
+++ b/src/chat.cob
@@ -1,3 +1,28 @@
+*> --- SendChatMessage ---
+*> Send a chat message to a specific client. A client ID of 0 means to write the message to the server console.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. SendChatMessage.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    COPY DD-CLIENTS.
+    01 BYTE-COUNT               BINARY-LONG UNSIGNED.
+LINKAGE SECTION.
+    01 LK-CLIENT-ID             BINARY-LONG UNSIGNED.
+    01 LK-MESSAGE               PIC X ANY LENGTH.
+    01 LK-COLOR                 PIC X(16).
+
+PROCEDURE DIVISION USING LK-CLIENT-ID LK-MESSAGE LK-COLOR.
+    MOVE FUNCTION STORED-CHAR-LENGTH(LK-MESSAGE) TO BYTE-COUNT
+    IF LK-CLIENT-ID = 0
+        DISPLAY LK-MESSAGE(1:BYTE-COUNT)
+        GOBACK
+    END-IF
+    CALL "SendPacket-SystemChat" USING LK-CLIENT-ID LK-MESSAGE BYTE-COUNT LK-COLOR
+    GOBACK.
+
+END PROGRAM SendChatMessage.
+
 *> --- BroadcastChatMessage ---
 *> Send a chat message to all clients in the "play" state, and log it to the server console.
 IDENTIFICATION DIVISION.
@@ -46,4 +71,3 @@ PROCEDURE DIVISION USING LK-EXCEPT-CLIENT-ID LK-MESSAGE LK-MESSAGE-LENGTH LK-COL
     GOBACK.
 
 END PROGRAM BroadcastChatMessageExcept.
-

--- a/src/commands.cob
+++ b/src/commands.cob
@@ -1,3 +1,26 @@
+*> --- RegisterCommand ---
+*> Register a command with the server.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterCommand.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    *> shared data
+    COPY DD-COMMANDS.
+LINKAGE SECTION.
+    01 LK-NAME              PIC X ANY LENGTH.
+    01 LK-HELP              PIC X ANY LENGTH.
+    01 LK-PTR-EXECUTE       PROGRAM-POINTER.
+
+PROCEDURE DIVISION USING LK-NAME LK-HELP LK-PTR-EXECUTE.
+    ADD 1 TO COMMAND-COUNT
+    MOVE LK-NAME TO COMMAND-NAME(COMMAND-COUNT)
+    MOVE LK-HELP TO COMMAND-HELP(COMMAND-COUNT)
+    MOVE LK-PTR-EXECUTE TO COMMAND-PTR-EXECUTE(COMMAND-COUNT)
+    GOBACK.
+
+END PROGRAM RegisterCommand.
+
 *> --- HandleCommand ---
 *> Handle a command, either input via the server console (client id = 0), or sent by a player (client id > 0).
 IDENTIFICATION DIVISION.
@@ -5,47 +28,24 @@ PROGRAM-ID. HandleCommand.
 
 DATA DIVISION.
 WORKING-STORAGE SECTION.
+    *> shared data
+    COPY DD-COMMANDS.
     *> constants
     01 C-COLOR-WHITE            PIC X(16)                   VALUE "white".
     *> command parsing
     01 OFFSET                   BINARY-LONG UNSIGNED.
     01 INPUT-LENGTH             BINARY-LONG UNSIGNED.
     01 INPUT-INDEX              BINARY-LONG UNSIGNED.
-    01 PART-COUNT               BINARY-LONG UNSIGNED.
     01 PARTS.
+        02 PART-COUNT           BINARY-LONG UNSIGNED.
         02 PART OCCURS 128 TIMES.
             03 PART-VALUE       PIC X(256).
             03 PART-LENGTH      BINARY-LONG UNSIGNED.
     *> command handling
-    01 PART-INDEX               BINARY-LONG UNSIGNED.
-    01 PLAYER-ID                BINARY-LONG UNSIGNED.
-    01 BUFFER                   PIC X(64000).
-    01 BUFFER-POS               BINARY-LONG UNSIGNED.
-    01 BYTE-COUNT               BINARY-LONG UNSIGNED.
-    01 TEMP-INT8                BINARY-CHAR.
-    01 TEMP-INT64               BINARY-LONG-LONG.
-    01 TEMP-INT64-PIC           PIC -(19)9.
-    01 TEMP-FLOAT               FLOAT-SHORT.
-    *> shared data
-    COPY DD-CLIENTS.
-    COPY DD-PLAYERS.
-    COPY DD-WHITELIST.
-    *> help text
-    01 HELP-TEXT-COUNT          BINARY-LONG UNSIGNED.
-    01 HELP-TEXT                PIC X(256) OCCURS 16 TIMES.
-    *> game mode enum to string
-    01 GAMEMODE-STRING-ENUM.
-        02 SURVIVAL-MODE        PIC X(16) VALUE "Survival Mode".
-        02 CREATIVE-MODE        PIC X(16) VALUE "Creative Mode".
-        02 ADVENTURE-MODE       PIC X(16) VALUE "Adventure Mode".
-        02 SPECTATOR-MODE       PIC X(16) VALUE "Spectator Mode".
-    01 GAMEMODE-STRINGS         REDEFINES GAMEMODE-STRING-ENUM.
-        02 GAMEMODE-STRING      PIC X(16) OCCURS 4 TIMES.
-    *> whitelist commands
-    01 WHITELIST-INDEX          BINARY-LONG UNSIGNED.
-    01 WHITELIST-FAILURE        BINARY-CHAR UNSIGNED.
-    01 WHITELIST-TEMP-UUID      PIC X(16).
-    01 WHITELIST-TEMP-NAME      PIC X(16).
+    01 BUFFER                   PIC X(255).
+    01 COMMAND-INDEX            BINARY-LONG UNSIGNED.
+    01 PTR                      PROGRAM-POINTER.
+    01 PRINT-USAGE              BINARY-CHAR UNSIGNED.
 LINKAGE SECTION.
     01 LK-CLIENT-ID             BINARY-LONG UNSIGNED.
     01 LK-INPUT                 PIC X(256).
@@ -54,13 +54,6 @@ LINKAGE SECTION.
 PROCEDURE DIVISION USING LK-CLIENT-ID LK-INPUT LK-INPUT-LENGTH.
     *> TODO: Implement a permission system to restrict commands.
     *>       Make sure to double-check which commands are admin-only - e.g., "/say" is, while it may not seem like it.
-
-    EVALUATE LK-CLIENT-ID
-        WHEN 0
-            MOVE 0 TO PLAYER-ID
-        WHEN OTHER
-            MOVE CLIENT-PLAYER(LK-CLIENT-ID) TO PLAYER-ID
-    END-EVALUATE
 
     *> TODO: Log admin commands
 
@@ -105,205 +98,28 @@ PROCEDURE DIVISION USING LK-CLIENT-ID LK-INPUT LK-INPUT-LENGTH.
         EXIT SECTION
     END-IF
 
-    *> Handle the command
-    EVALUATE PART-VALUE(1)
-        WHEN "gamemode"
-            IF PART-COUNT NOT = 2
-                MOVE "Usage: /gamemode <gamemode>" TO BUFFER
-                CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+    *> Handle the command by looking up the first part
+    PERFORM VARYING COMMAND-INDEX FROM 1 BY 1 UNTIL COMMAND-INDEX > COMMAND-COUNT
+        IF COMMAND-NAME(COMMAND-INDEX) = PART-VALUE(1)(1:PART-LENGTH(1))
+            MOVE COMMAND-PTR-EXECUTE(COMMAND-INDEX) TO PTR
+            MOVE 0 TO PRINT-USAGE
+            CALL PTR USING LK-CLIENT-ID PARTS PRINT-USAGE
+            *> If the command executed successfully, exit the loop
+            IF PRINT-USAGE = 0
                 EXIT SECTION
             END-IF
-            EVALUATE PART-VALUE(2)
-                WHEN "survival"
-                    MOVE 0 TO PLAYER-GAMEMODE(PLAYER-ID)
-                    MOVE 0 TO PLAYER-FLYING(PLAYER-ID)
-                WHEN "creative"
-                    MOVE 1 TO PLAYER-GAMEMODE(PLAYER-ID)
-                WHEN "adventure"
-                    MOVE 2 TO PLAYER-GAMEMODE(PLAYER-ID)
-                    MOVE 0 TO PLAYER-FLYING(PLAYER-ID)
-                WHEN "spectator"
-                    MOVE 3 TO PLAYER-GAMEMODE(PLAYER-ID)
-                WHEN OTHER
-                    MOVE "Usage: /gamemode <gamemode>" TO BUFFER
-                    CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-                    EXIT SECTION
-            END-EVALUATE
-            INITIALIZE BUFFER
-            STRING "Set own game mode to " FUNCTION TRIM(GAMEMODE-STRING(PLAYER-GAMEMODE(PLAYER-ID) + 1)) INTO BUFFER
-            CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-            *> game event 3: change game mode
-            MOVE 3 TO TEMP-INT8
-            MOVE PLAYER-GAMEMODE(PLAYER-ID) TO TEMP-FLOAT
-            CALL "SendPacket-GameEvent" USING LK-CLIENT-ID TEMP-INT8 TEMP-FLOAT
-            CALL "SendPacket-PlayerAbilities" USING LK-CLIENT-ID PLAYER-GAMEMODE(PLAYER-ID) PLAYER-FLYING(PLAYER-ID)
+            *> Print the usage for the command
+            CALL "SendChatMessage" USING LK-CLIENT-ID COMMAND-HELP(COMMAND-INDEX) C-COLOR-WHITE
+            EXIT SECTION
+        END-IF
+    END-PERFORM
 
-        WHEN "help"
-            MOVE "Available commands:" TO HELP-TEXT(1)
-            MOVE "/gamemode <gamemode> - change your game mode" TO HELP-TEXT(2)
-            MOVE "/help - show this help" TO HELP-TEXT(3)
-            MOVE "/say <message> - broadcast a message" TO HELP-TEXT(4)
-            MOVE "/save - save the world" TO HELP-TEXT(5)
-            MOVE "/stop - stop the server" TO HELP-TEXT(6)
-            MOVE "/time set (day|noon|night|midnight|<time>) - change the time" TO HELP-TEXT(7)
-            MOVE "/whitelist (reload|list|add|remove) [player] - manage the whitelist" TO HELP-TEXT(8)
-            MOVE 8 TO HELP-TEXT-COUNT
-            PERFORM VARYING TEMP-INT64 FROM 1 BY 1 UNTIL TEMP-INT64 > HELP-TEXT-COUNT
-                CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID HELP-TEXT(TEMP-INT64) C-COLOR-WHITE
-            END-PERFORM
-
-        WHEN "say"
-            *> TODO handle empty message
-            *> sender prefix
-            IF LK-CLIENT-ID = 0
-                MOVE "[Server]" TO BUFFER
-                MOVE 8 TO BYTE-COUNT
-            ELSE
-                INITIALIZE BUFFER
-                STRING "[" PLAYER-NAME(PLAYER-ID)(1:PLAYER-NAME-LENGTH(PLAYER-ID)) "]" INTO BUFFER
-                MOVE FUNCTION STORED-CHAR-LENGTH(BUFFER) TO BYTE-COUNT
-            END-IF
-            *> message body
-            PERFORM VARYING PART-INDEX FROM 2 BY 1 UNTIL PART-INDEX > PART-COUNT
-                MOVE " " TO BUFFER(BYTE-COUNT + 1:1)
-                ADD 1 TO BYTE-COUNT
-                MOVE PART-VALUE(PART-INDEX) TO BUFFER(BYTE-COUNT + 1:PART-LENGTH(PART-INDEX))
-                ADD PART-LENGTH(PART-INDEX) TO BYTE-COUNT
-            END-PERFORM
-            *> broadcast it
-            CALL "BroadcastChatMessage" USING BUFFER BYTE-COUNT C-COLOR-WHITE
-
-        WHEN "save"
-            MOVE "Saving world" TO BUFFER
-            CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-            CALL "Server-Save"
-            MOVE "World saved" TO BUFFER
-            CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-
-        WHEN "stop"
-            CALL "Server-Stop"
-
-        WHEN "time"
-            IF PART-COUNT NOT = 3 OR PART-VALUE(2) NOT = "set"
-                MOVE "Usage: /time set (day|noon|night|midnight|<time>)" TO BUFFER
-                CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-                EXIT SECTION
-            END-IF
-            EVALUATE PART-VALUE(3)(1:PART-LENGTH(3))
-                WHEN "day"
-                    MOVE 1000 TO TEMP-INT64
-                WHEN "noon"
-                    MOVE 6000 TO TEMP-INT64
-                WHEN "night"
-                    MOVE 13000 TO TEMP-INT64
-                WHEN "midnight"
-                    MOVE 18000 TO TEMP-INT64
-                WHEN OTHER
-                    MOVE FUNCTION NUMVAL(PART-VALUE(3)) TO TEMP-INT64
-            END-EVALUATE
-            CALL "World-SetTime" USING TEMP-INT64
-            MOVE TEMP-INT64 TO TEMP-INT64-PIC
-            INITIALIZE BUFFER
-            STRING "Set the time to " FUNCTION TRIM(TEMP-INT64-PIC) INTO BUFFER
-            CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-
-        WHEN "whitelist"
-            IF PART-COUNT = 2 AND PART-VALUE(2) = "reload"
-                CALL "Whitelist-Read" USING WHITELIST-FAILURE
-                IF WHITELIST-FAILURE NOT = 0
-                    MOVE "Error reloading the whitelist" TO BUFFER
-                    CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-                    EXIT SECTION
-                END-IF
-                MOVE "Reloaded the whitelist" TO BUFFER
-                CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-                EXIT SECTION
-            END-IF
-            IF PART-COUNT = 2 AND PART-VALUE(2) = "list"
-                IF WHITELIST-LENGTH = 0
-                    MOVE "There are no whitelisted players" TO BUFFER
-                    CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-                    EXIT SECTION
-                END-IF
-                MOVE WHITELIST-LENGTH TO TEMP-INT64-PIC
-                INITIALIZE BUFFER
-                STRING "There are " FUNCTION TRIM(TEMP-INT64-PIC) " whitelisted player(s):" INTO BUFFER
-                COMPUTE BUFFER-POS = FUNCTION STORED-CHAR-LENGTH(BUFFER) + 2
-                PERFORM VARYING WHITELIST-INDEX FROM 1 BY 1 UNTIL WHITELIST-INDEX > WHITELIST-LENGTH
-                    IF WHITELIST-INDEX > 1
-                        MOVE ", " TO BUFFER(BUFFER-POS:2)
-                        ADD 2 TO BUFFER-POS
-                    END-IF
-                    MOVE FUNCTION STORED-CHAR-LENGTH(WHITELIST-NAME(WHITELIST-INDEX)) TO BYTE-COUNT
-                    MOVE WHITELIST-NAME(WHITELIST-INDEX)(1:BYTE-COUNT) TO BUFFER(BUFFER-POS:BYTE-COUNT)
-                    ADD BYTE-COUNT TO BUFFER-POS
-                END-PERFORM
-                CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-                EXIT SECTION
-            END-IF
-            IF PART-COUNT = 3
-                MOVE PART-VALUE(3) TO WHITELIST-TEMP-NAME
-                MOVE FUNCTION STORED-CHAR-LENGTH(WHITELIST-TEMP-NAME) TO BYTE-COUNT
-                *> TODO refactor this to a subroutine (currently duplicated with server)
-                MOVE X"00000000000000000000000000000000" TO WHITELIST-TEMP-UUID
-                MOVE WHITELIST-TEMP-NAME(1:BYTE-COUNT) TO WHITELIST-TEMP-UUID(1:BYTE-COUNT)
-                IF PART-VALUE(2) = "add"
-                    CALL "Whitelist-Add" USING WHITELIST-TEMP-UUID WHITELIST-TEMP-NAME BYTE-COUNT WHITELIST-FAILURE
-                    IF WHITELIST-FAILURE NOT = 0
-                        MOVE "Player is already whitelisted" TO BUFFER
-                    ELSE
-                        INITIALIZE BUFFER
-                        STRING "Added " FUNCTION TRIM(WHITELIST-TEMP-NAME(1:BYTE-COUNT)) " to the whitelist" INTO BUFFER
-                    END-IF
-                    CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-                    EXIT SECTION
-                END-IF
-                IF PART-VALUE(2) = "remove"
-                    CALL "Whitelist-Remove" USING WHITELIST-TEMP-UUID WHITELIST-TEMP-NAME BYTE-COUNT WHITELIST-FAILURE
-                    IF WHITELIST-FAILURE NOT = 0
-                        MOVE "Player is not whitelisted" TO BUFFER
-                    ELSE
-                        INITIALIZE BUFFER
-                        STRING "Removed " FUNCTION TRIM(WHITELIST-TEMP-NAME(1:BYTE-COUNT)) " from the whitelist" INTO BUFFER
-                    END-IF
-                    CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-                    EXIT SECTION
-                END-IF
-            END-IF
-            MOVE "Usage: /whitelist (reload|list|add|remove) [player]" TO BUFFER
-            CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-
-        WHEN OTHER
-            INITIALIZE BUFFER
-            STRING "Unknown command: " PART-VALUE(1)(1:PART-LENGTH(1)) INTO BUFFER
-            CALL "HandleCommand-SendToClient" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
-
-    END-EVALUATE
+    *> Command not found
+    INITIALIZE BUFFER
+    STRING "Unknown command: " PART-VALUE(1)(1:PART-LENGTH(1)) INTO BUFFER
+    CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
 
     GOBACK.
-
-    *> --- HandleCommand-SendToClient ---
-    *> Subroutine to send a message to the client (player or server console) that executed the command.
-    IDENTIFICATION DIVISION.
-    PROGRAM-ID. HandleCommand-SendToClient.
-
-    DATA DIVISION.
-    WORKING-STORAGE SECTION.
-        COPY DD-CLIENTS.
-        01 BYTE-COUNT               BINARY-LONG UNSIGNED.
-    LINKAGE SECTION.
-        01 LK-CLIENT-ID             BINARY-LONG UNSIGNED.
-        01 LK-MESSAGE               PIC X ANY LENGTH.
-        01 LK-COLOR                 PIC X(16).
-
-    PROCEDURE DIVISION USING LK-CLIENT-ID LK-MESSAGE LK-COLOR.
-        MOVE FUNCTION STORED-CHAR-LENGTH(LK-MESSAGE) TO BYTE-COUNT
-        IF LK-CLIENT-ID = 0
-            DISPLAY LK-MESSAGE(1:BYTE-COUNT)
-            GOBACK
-        END-IF
-        CALL "SendPacket-SystemChat" USING LK-CLIENT-ID LK-MESSAGE BYTE-COUNT LK-COLOR
-        GOBACK.
 
 END PROGRAM HandleCommand.
 
@@ -339,6 +155,8 @@ LINKAGE SECTION.
 PROCEDURE DIVISION USING LK-CLIENT-ID.
     IF IS-INITIALIZED = 0
         MOVE 1 TO IS-INITIALIZED
+
+        *> TODO make this part of command registration
 
         *> root node
         MOVE 1 TO COMMAND-NODE-COUNT

--- a/src/commands/gamemode.cob
+++ b/src/commands/gamemode.cob
@@ -1,0 +1,87 @@
+*> --- RegisterCommand-GameMode ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterCommand-GameMode.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 COMMAND-NAME                 PIC X(100)                  VALUE "gamemode".
+    01 COMMAND-HELP                 PIC X(255)                  VALUE "/gamemode <gamemode> - change your game mode".
+    01 PTR                          PROGRAM-POINTER.
+
+PROCEDURE DIVISION.
+    SET PTR TO ENTRY "Callback-Execute"
+    CALL "RegisterCommand" USING COMMAND-NAME COMMAND-HELP PTR
+    GOBACK.
+
+    *> --- Callback-Execute ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Execute.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        COPY DD-CLIENTS.
+        COPY DD-PLAYERS.
+        01 C-COLOR-WHITE            PIC X(16)                   VALUE "white".
+        01 BUFFER                   PIC X(255).
+        01 PLAYER-ID                BINARY-LONG UNSIGNED.
+        01 GAME-EVENT-TYPE          BINARY-CHAR UNSIGNED.
+        01 GAME-EVENT-VALUE         FLOAT-SHORT.
+        *> game mode enum to string
+        01 GAMEMODE-STRING-ENUM.
+            02 SURVIVAL-MODE        PIC X(16) VALUE "Survival Mode".
+            02 CREATIVE-MODE        PIC X(16) VALUE "Creative Mode".
+            02 ADVENTURE-MODE       PIC X(16) VALUE "Adventure Mode".
+            02 SPECTATOR-MODE       PIC X(16) VALUE "Spectator Mode".
+        01 GAMEMODE-STRINGS         REDEFINES GAMEMODE-STRING-ENUM.
+            02 GAMEMODE-STRING      PIC X(16) OCCURS 4 TIMES.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-COMMAND-EXECUTE.
+
+    PROCEDURE DIVISION USING LK-CLIENT-ID LK-PARTS LK-PRINT-USAGE.
+        IF LK-PART-COUNT NOT = 2
+            MOVE 1 TO LK-PRINT-USAGE
+            GOBACK
+        END-IF
+
+        EVALUATE LK-CLIENT-ID
+            WHEN 0
+                *> TODO handle console
+                MOVE "This command is not available from the console" TO BUFFER
+                CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+                GOBACK
+            WHEN OTHER
+                MOVE CLIENT-PLAYER(LK-CLIENT-ID) TO PLAYER-ID
+        END-EVALUATE
+
+        EVALUATE LK-PART-VALUE(2)
+            WHEN "survival"
+                MOVE 0 TO PLAYER-GAMEMODE(PLAYER-ID)
+                MOVE 0 TO PLAYER-FLYING(PLAYER-ID)
+            WHEN "creative"
+                MOVE 1 TO PLAYER-GAMEMODE(PLAYER-ID)
+            WHEN "adventure"
+                MOVE 2 TO PLAYER-GAMEMODE(PLAYER-ID)
+                MOVE 0 TO PLAYER-FLYING(PLAYER-ID)
+            WHEN "spectator"
+                MOVE 3 TO PLAYER-GAMEMODE(PLAYER-ID)
+            WHEN OTHER
+                MOVE 1 TO LK-PRINT-USAGE
+                GOBACK
+        END-EVALUATE
+
+        INITIALIZE BUFFER
+        STRING "Set own game mode to " FUNCTION TRIM(GAMEMODE-STRING(PLAYER-GAMEMODE(PLAYER-ID) + 1)) INTO BUFFER
+        CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+
+        *> game event 3: change game mode
+        MOVE 3 TO GAME-EVENT-TYPE
+        MOVE PLAYER-GAMEMODE(PLAYER-ID) TO GAME-EVENT-VALUE
+        CALL "SendPacket-GameEvent" USING LK-CLIENT-ID GAME-EVENT-TYPE GAME-EVENT-VALUE
+
+        CALL "SendPacket-PlayerAbilities" USING LK-CLIENT-ID PLAYER-GAMEMODE(PLAYER-ID) PLAYER-FLYING(PLAYER-ID)
+
+        GOBACK.
+
+    END PROGRAM Callback-Execute.
+
+END PROGRAM RegisterCommand-GameMode.

--- a/src/commands/help.cob
+++ b/src/commands/help.cob
@@ -1,0 +1,47 @@
+*> --- RegisterCommand-Help ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterCommand-Help.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 COMMAND-NAME                 PIC X(100)                  VALUE "help".
+    01 COMMAND-HELP                 PIC X(255)                  VALUE "/help - show this help".
+    01 PTR                          PROGRAM-POINTER.
+
+PROCEDURE DIVISION.
+    SET PTR TO ENTRY "Callback-Execute"
+    CALL "RegisterCommand" USING COMMAND-NAME COMMAND-HELP PTR
+    GOBACK.
+
+    *> --- Callback-Execute ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Execute.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        COPY DD-COMMANDS.
+        01 C-COLOR-WHITE            PIC X(16)                   VALUE "white".
+        01 BUFFER                   PIC X(255).
+        01 COMMAND-INDEX            BINARY-LONG UNSIGNED.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-COMMAND-EXECUTE.
+
+    PROCEDURE DIVISION USING LK-CLIENT-ID LK-PARTS LK-PRINT-USAGE.
+        IF LK-PART-COUNT NOT = 1
+            MOVE 1 TO LK-PRINT-USAGE
+            GOBACK
+        END-IF
+
+        MOVE "Available commands:" TO BUFFER
+        CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+
+        PERFORM VARYING COMMAND-INDEX FROM 1 BY 1 UNTIL COMMAND-INDEX > COMMAND-COUNT
+            MOVE COMMAND-HELP(COMMAND-INDEX) TO BUFFER
+            CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+        END-PERFORM
+
+        GOBACK.
+
+    END PROGRAM Callback-Execute.
+
+END PROGRAM RegisterCommand-Help.

--- a/src/commands/save.cob
+++ b/src/commands/save.cob
@@ -1,0 +1,45 @@
+*> --- RegisterCommand-Save ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterCommand-Save.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 COMMAND-NAME                 PIC X(100)                  VALUE "save".
+    01 COMMAND-HELP                 PIC X(255)                  VALUE "/save - save the world".
+    01 PTR                          PROGRAM-POINTER.
+
+PROCEDURE DIVISION.
+    SET PTR TO ENTRY "Callback-Execute"
+    CALL "RegisterCommand" USING COMMAND-NAME COMMAND-HELP PTR
+    GOBACK.
+
+    *> --- Callback-Execute ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Execute.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        01 C-COLOR-WHITE            PIC X(16)                   VALUE "white".
+        01 BUFFER                   PIC X(255).
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-COMMAND-EXECUTE.
+
+    PROCEDURE DIVISION USING LK-CLIENT-ID LK-PARTS LK-PRINT-USAGE.
+        IF LK-PART-COUNT NOT = 1
+            MOVE 1 TO LK-PRINT-USAGE
+            GOBACK
+        END-IF
+
+        MOVE "Saving world" TO BUFFER
+        CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+
+        CALL "Server-Save"
+
+        MOVE "World saved" TO BUFFER
+        CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+
+        GOBACK.
+
+    END PROGRAM Callback-Execute.
+
+END PROGRAM RegisterCommand-Save.

--- a/src/commands/say.cob
+++ b/src/commands/say.cob
@@ -1,0 +1,62 @@
+*> --- RegisterCommand-Say ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterCommand-Say.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 COMMAND-NAME                 PIC X(100)                  VALUE "say".
+    01 COMMAND-HELP                 PIC X(255)                  VALUE "/say <message> - broadcast a message".
+    01 PTR                          PROGRAM-POINTER.
+
+PROCEDURE DIVISION.
+    SET PTR TO ENTRY "Callback-Execute"
+    CALL "RegisterCommand" USING COMMAND-NAME COMMAND-HELP PTR
+    GOBACK.
+
+    *> --- Callback-Execute ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Execute.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        COPY DD-CLIENTS.
+        COPY DD-PLAYERS.
+        01 C-COLOR-WHITE            PIC X(16)                   VALUE "white".
+        01 BUFFER                   PIC X(1024).
+        01 BYTE-COUNT               BINARY-LONG UNSIGNED.
+        01 PLAYER-ID                BINARY-LONG UNSIGNED.
+        01 PART-INDEX               BINARY-LONG UNSIGNED.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-COMMAND-EXECUTE.
+
+    PROCEDURE DIVISION USING LK-CLIENT-ID LK-PARTS LK-PRINT-USAGE.
+        *> TODO handle empty message
+
+        *> sender prefix
+        EVALUATE LK-CLIENT-ID
+            WHEN 0
+                MOVE "[Server]" TO BUFFER
+                MOVE 8 TO BYTE-COUNT
+            WHEN OTHER
+                MOVE CLIENT-PLAYER(LK-CLIENT-ID) TO PLAYER-ID
+                INITIALIZE BUFFER
+                STRING "[" PLAYER-NAME(PLAYER-ID)(1:PLAYER-NAME-LENGTH(PLAYER-ID)) "]" INTO BUFFER
+                MOVE FUNCTION STORED-CHAR-LENGTH(BUFFER) TO BYTE-COUNT
+        END-EVALUATE
+
+        *> message body
+        PERFORM VARYING PART-INDEX FROM 2 BY 1 UNTIL PART-INDEX > LK-PART-COUNT
+            MOVE " " TO BUFFER(BYTE-COUNT + 1:1)
+            ADD 1 TO BYTE-COUNT
+            MOVE LK-PART-VALUE(PART-INDEX) TO BUFFER(BYTE-COUNT + 1:LK-PART-LENGTH(PART-INDEX))
+            ADD LK-PART-LENGTH(PART-INDEX) TO BYTE-COUNT
+        END-PERFORM
+
+        *> broadcast it
+        CALL "BroadcastChatMessage" USING BUFFER BYTE-COUNT C-COLOR-WHITE
+
+        GOBACK.
+
+    END PROGRAM Callback-Execute.
+
+END PROGRAM RegisterCommand-Say.

--- a/src/commands/stop.cob
+++ b/src/commands/stop.cob
@@ -1,0 +1,34 @@
+*> --- RegisterCommand-Stop ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterCommand-Stop.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 COMMAND-NAME                 PIC X(100)                  VALUE "stop".
+    01 COMMAND-HELP                 PIC X(255)                  VALUE "/stop - stop the server".
+    01 PTR                          PROGRAM-POINTER.
+
+PROCEDURE DIVISION.
+    SET PTR TO ENTRY "Callback-Execute"
+    CALL "RegisterCommand" USING COMMAND-NAME COMMAND-HELP PTR
+    GOBACK.
+
+    *> --- Callback-Execute ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Execute.
+
+    DATA DIVISION.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-COMMAND-EXECUTE.
+
+    PROCEDURE DIVISION USING LK-CLIENT-ID LK-PARTS LK-PRINT-USAGE.
+        IF LK-PART-COUNT NOT = 1
+            MOVE 1 TO LK-PRINT-USAGE
+            GOBACK
+        END-IF
+        CALL "Server-Stop"
+        GOBACK.
+
+    END PROGRAM Callback-Execute.
+
+END PROGRAM RegisterCommand-Stop.

--- a/src/commands/time.cob
+++ b/src/commands/time.cob
@@ -1,0 +1,61 @@
+*> --- RegisterCommand-Time ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterCommand-Time.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 COMMAND-NAME                 PIC X(100)                  VALUE "time".
+    01 COMMAND-HELP                 PIC X(255)                  VALUE "/time set (day|noon|night|midnight|<time>) - change the time".
+    01 PTR                          PROGRAM-POINTER.
+
+PROCEDURE DIVISION.
+    SET PTR TO ENTRY "Callback-Execute"
+    CALL "RegisterCommand" USING COMMAND-NAME COMMAND-HELP PTR
+    GOBACK.
+
+    *> --- Callback-Execute ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Execute.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        COPY DD-CLIENTS.
+        COPY DD-PLAYERS.
+        01 C-COLOR-WHITE            PIC X(16)                   VALUE "white".
+        01 BUFFER                   PIC X(255).
+        01 TEMP-INT64               BINARY-LONG.
+        01 TEMP-INT64-PIC           PIC -(19)9.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-COMMAND-EXECUTE.
+
+    PROCEDURE DIVISION USING LK-CLIENT-ID LK-PARTS LK-PRINT-USAGE.
+        IF LK-PART-COUNT NOT = 3 OR LK-PART-VALUE(2) NOT = "set"
+            MOVE 1 TO LK-PRINT-USAGE
+            GOBACK
+        END-IF
+
+        EVALUATE LK-PART-VALUE(3)(1:LK-PART-LENGTH(3))
+            WHEN "day"
+                MOVE 1000 TO TEMP-INT64
+            WHEN "noon"
+                MOVE 6000 TO TEMP-INT64
+            WHEN "night"
+                MOVE 13000 TO TEMP-INT64
+            WHEN "midnight"
+                MOVE 18000 TO TEMP-INT64
+            WHEN OTHER
+                MOVE FUNCTION NUMVAL(LK-PART-VALUE(3)) TO TEMP-INT64
+        END-EVALUATE
+
+        CALL "World-SetTime" USING TEMP-INT64
+
+        MOVE TEMP-INT64 TO TEMP-INT64-PIC
+        INITIALIZE BUFFER
+        STRING "Set the time to " FUNCTION TRIM(TEMP-INT64-PIC) INTO BUFFER
+        CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+
+        GOBACK.
+
+    END PROGRAM Callback-Execute.
+
+END PROGRAM RegisterCommand-Time.

--- a/src/commands/whitelist.cob
+++ b/src/commands/whitelist.cob
@@ -1,0 +1,109 @@
+*> --- RegisterCommand-Whitelist ---
+IDENTIFICATION DIVISION.
+PROGRAM-ID. RegisterCommand-Whitelist.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 COMMAND-NAME                 PIC X(100)                  VALUE "whitelist".
+    01 COMMAND-HELP                 PIC X(255)                  VALUE "/whitelist (reload|list|add|remove) [player] - manage the whitelist".
+    01 PTR                          PROGRAM-POINTER.
+
+PROCEDURE DIVISION.
+    SET PTR TO ENTRY "Callback-Execute"
+    CALL "RegisterCommand" USING COMMAND-NAME COMMAND-HELP PTR
+    GOBACK.
+
+    *> --- Callback-Execute ---
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. Callback-Execute.
+
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+        COPY DD-WHITELIST.
+        01 C-COLOR-WHITE            PIC X(16)                   VALUE "white".
+        01 BUFFER                   PIC X(255).
+        01 BUFFER-POS               BINARY-LONG UNSIGNED.
+        01 BYTE-COUNT               BINARY-LONG UNSIGNED.
+        01 WHITELIST-INDEX          BINARY-LONG UNSIGNED.
+        01 FAILURE                  BINARY-CHAR UNSIGNED.
+        01 TEMP-UUID                PIC X(16).
+        01 TEMP-NAME                PIC X(16).
+        01 TEMP-INT64-PIC           PIC -(19)9.
+    LINKAGE SECTION.
+        COPY DD-CALLBACK-COMMAND-EXECUTE.
+
+    PROCEDURE DIVISION USING LK-CLIENT-ID LK-PARTS LK-PRINT-USAGE.
+        IF LK-PART-COUNT = 2 AND LK-PART-VALUE(2) = "reload"
+            CALL "Whitelist-Read" USING FAILURE
+            IF FAILURE NOT = 0
+                MOVE "Error reloading the whitelist" TO BUFFER
+                CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+                GOBACK
+            END-IF
+            MOVE "Reloaded the whitelist" TO BUFFER
+            CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+            GOBACK
+        END-IF
+
+        IF LK-PART-COUNT = 2 AND LK-PART-VALUE(2) = "list"
+            IF WHITELIST-LENGTH = 0
+                MOVE "There are no whitelisted players" TO BUFFER
+                CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+                GOBACK
+            END-IF
+            MOVE WHITELIST-LENGTH TO TEMP-INT64-PIC
+            INITIALIZE BUFFER
+            STRING "There are " FUNCTION TRIM(TEMP-INT64-PIC) " whitelisted player(s):" INTO BUFFER
+            COMPUTE BUFFER-POS = FUNCTION STORED-CHAR-LENGTH(BUFFER) + 2
+            PERFORM VARYING WHITELIST-INDEX FROM 1 BY 1 UNTIL WHITELIST-INDEX > WHITELIST-LENGTH
+                IF WHITELIST-INDEX > 1
+                    MOVE ", " TO BUFFER(BUFFER-POS:2)
+                    ADD 2 TO BUFFER-POS
+                END-IF
+                MOVE FUNCTION STORED-CHAR-LENGTH(WHITELIST-NAME(WHITELIST-INDEX)) TO BYTE-COUNT
+                MOVE WHITELIST-NAME(WHITELIST-INDEX)(1:BYTE-COUNT) TO BUFFER(BUFFER-POS:BYTE-COUNT)
+                ADD BYTE-COUNT TO BUFFER-POS
+            END-PERFORM
+            CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+            GOBACK
+        END-IF
+
+        IF LK-PART-COUNT = 3
+            MOVE LK-PART-VALUE(3) TO TEMP-NAME
+            MOVE FUNCTION STORED-CHAR-LENGTH(TEMP-NAME) TO BYTE-COUNT
+            *> TODO refactor this to a subroutine (currently duplicated with server)
+            MOVE X"00000000000000000000000000000000" TO TEMP-UUID
+            MOVE TEMP-NAME(1:BYTE-COUNT) TO TEMP-UUID(1:BYTE-COUNT)
+
+            IF LK-PART-VALUE(2) = "add"
+                CALL "Whitelist-Add" USING TEMP-UUID TEMP-NAME BYTE-COUNT FAILURE
+                IF FAILURE NOT = 0
+                    MOVE "Player is already whitelisted" TO BUFFER
+                ELSE
+                    INITIALIZE BUFFER
+                    STRING "Added " FUNCTION TRIM(TEMP-NAME(1:BYTE-COUNT)) " to the whitelist" INTO BUFFER
+                END-IF
+                CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+                GOBACK
+            END-IF
+
+            IF LK-PART-VALUE(2) = "remove"
+                CALL "Whitelist-Remove" USING TEMP-UUID TEMP-NAME BYTE-COUNT FAILURE
+                IF FAILURE NOT = 0
+                    MOVE "Player is not whitelisted" TO BUFFER
+                ELSE
+                    INITIALIZE BUFFER
+                    STRING "Removed " FUNCTION TRIM(TEMP-NAME(1:BYTE-COUNT)) " from the whitelist" INTO BUFFER
+                END-IF
+                CALL "SendChatMessage" USING LK-CLIENT-ID BUFFER C-COLOR-WHITE
+                GOBACK
+            END-IF
+        END-IF
+
+        MOVE 1 TO LK-PRINT-USAGE
+
+        GOBACK.
+
+    END PROGRAM Callback-Execute.
+
+END PROGRAM RegisterCommand-Whitelist.

--- a/src/copybooks/DD-CALLBACK-COMMAND-EXECUTE.cpy
+++ b/src/copybooks/DD-CALLBACK-COMMAND-EXECUTE.cpy
@@ -1,0 +1,13 @@
+*> --- Copybook: callback parameters for command execution ---
+
+*> Client index, 0 for server
+01 LK-CLIENT-ID                 BINARY-CHAR.
+
+*> Command name, followed by arguments
+01 LK-PARTS.
+    02 LK-PART-COUNT            BINARY-LONG UNSIGNED.
+    02 LK-PART OCCURS 128 TIMES.
+        03 LK-PART-VALUE        PIC X(256).
+        03 LK-PART-LENGTH       BINARY-LONG UNSIGNED.
+
+01 LK-PRINT-USAGE               BINARY-CHAR UNSIGNED.

--- a/src/copybooks/DD-COMMANDS.cpy
+++ b/src/copybooks/DD-COMMANDS.cpy
@@ -1,0 +1,16 @@
+*> --- Copybook: registered commands ---
+
+*> The number of commands that can be registered.
+78 MAX-COMMANDS VALUE 100.
+
+*> Registered commands.
+01 COMMANDS EXTERNAL.
+    02 COMMAND-COUNT BINARY-LONG UNSIGNED.
+    02 COMMAND OCCURS MAX-COMMANDS TIMES.
+        *> The command name.
+        03 COMMAND-NAME PIC X(100).
+        *> The command help text.
+        *> TODO: Synthesize this from the command's tree structure.
+        03 COMMAND-HELP PIC X(255).
+        *> Called when the command is executed.
+        03 COMMAND-PTR-EXECUTE USAGE PROGRAM-POINTER.

--- a/src/server.cob
+++ b/src/server.cob
@@ -224,6 +224,18 @@ RegisterBlocks.
     CALL "RegisterBlock-Lava"
     .
 
+RegisterCommands.
+    DISPLAY "Registering commands"
+
+    CALL "RegisterCommand-GameMode"
+    CALL "RegisterCommand-Help"
+    CALL "RegisterCommand-Say"
+    CALL "RegisterCommand-Save"
+    CALL "RegisterCommand-Stop"
+    CALL "RegisterCommand-Time"
+    CALL "RegisterCommand-Whitelist"
+    .
+
 LoadProperties.
     DISPLAY "Loading server properties"
     CALL "ServerProperties-Read" USING DATA-FAILURE


### PR DESCRIPTION
The server/in-game commands are no longer part of one big source file, but can instead be registered similar to block and item callbacks, using a program pointer for execution. One limitation still exists in that the node structure (for client-side auto completion) must still be hardcoded. This will be addressed in a future patch.

To enable this change, the `HandleCommand-SendToClient` subroutine is moved to chat.cob as `SendChatMessage` and used throughout.