### PR TITLE
feat: Link C++ library statically, producing a single binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,13 +34,9 @@ RUN apt-get update && \
 
 # Copy the build results
 COPY --from=build /app/cobolcraft .
-COPY --from=build /app/*.so .
 COPY --from=build /app/blobs ./blobs
 COPY --from=build /app/data/generated/reports/*.json ./data/generated/reports/
 COPY --from=build /app/data/generated/data ./data/generated/data
-
-# Include runtime dependencies
-ENV COB_PRE_LOAD=COBOLCRAFT_UTIL
 
 # Run the server within Tini (to handle signals properly)
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ The remaining COBOL sources are located in the `src/` directory, including `src/
 of CobolCraft.
 
 Only functionality that is not feasible in COBOL is implemented in C++, such as low-level TCP socket management,
-precise timing, or process signal handling.
-These sources are located in the `cpp/` directory and get compiled into a shared library (`.so` on Linux).
+precise timing, or process signal handling, and is located in the `cpp/` directory.
+
+All sources (COBOL and C++) are compiled into a single `cobolcraft` binary.
 
 ### Packet Blobs
 


### PR DESCRIPTION
The primary motivation for dynamic linking of C++ libraries was the 3rd-party CBL_GC_SOCKET library. Since that is gone, we have no need to produce any shared libraries, and can generate a single standalone binary instead.