### PR TITLE
fix: Abbreviate condition in PROC-SKIP-WHITESPACE.cpy

### DIFF
--- a/src/copybooks/PROC-SKIP-WHITESPACE.cpy
+++ b/src/copybooks/PROC-SKIP-WHITESPACE.cpy
@@ -1,6 +1,6 @@
 *> --- Copybook: skip whitespace in a string starting at a given index ---
 PERFORM UNTIL IDX > LEN
-    IF NOT (STR(IDX:1) = X"20" OR STR(IDX:1) = X"09" OR STR(IDX:1) = X"0A" OR STR(IDX:1) = X"0D")
+    IF NOT (STR(IDX:1) = X"20" OR X"09" OR X"0A" OR X"0D")
         EXIT PERFORM
     END-IF
     ADD 1 TO IDX


### PR DESCRIPTION
Removed redundant use of variable in comparison.