### PR TITLE
feat: Add support for biome data in chunk sections

### DIFF
--- a/src/copybooks/DD-WORLD.cpy
+++ b/src/copybooks/DD-WORLD.cpy
@@ -19,10 +19,10 @@
             04 WORLD-SECTION-BLOCKS.
                 05 WORLD-BLOCK OCCURS 4096 TIMES.
                     06 WORLD-BLOCK-ID           BINARY-LONG UNSIGNED.
-            *> section biome ID
-            *> TODO: This is kind of a hack, just to get a default "plains" biome instead of whatever is added first to
-            *> the biome registry (usually badlands). We should have a separate biome array.
-            04 WORLD-SECTION-BIOME-ID    BINARY-LONG UNSIGNED.
+            *> biome IDs (4x4x4)
+            04 WORLD-SECTION-BIOMES.
+                05 WORLD-BIOME OCCURS 64 TIMES.
+                    06 WORLD-BIOME-ID           BINARY-LONG UNSIGNED.
         03 WORLD-BLOCK-ENTITY-COUNT BINARY-LONG UNSIGNED.
         *> block entity IDs for each block
         03 WORLD-BLOCK-ENTITIES.

--- a/src/nbt-decode.cob
+++ b/src/nbt-decode.cob
@@ -725,3 +725,61 @@ PROCEDURE DIVISION USING LK-STATE LK-BUFFER LK-UUID.
     GOBACK.
 
 END PROGRAM NbtDecode-UUID.
+
+*> --- NbtDecode-SkipUntilTag ---
+*> A utility procedure to skip until a tag with a given name is found. If found, the offset will be set to the
+*> start of the tag. Otherwise, the offset will be at the end of the compound, and the "at end" flag will be set.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. NbtDecode-SkipUntilTag.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 TAG-NAME             PIC X(256).
+    01 NAME-LEN             BINARY-LONG UNSIGNED.
+LINKAGE SECTION.
+    COPY DD-NBT-DECODER REPLACING LEADING ==NBT-DECODER== BY ==LK==.
+    01 LK-BUFFER            PIC X ANY LENGTH.
+    01 LK-TAG-NAME          PIC X ANY LENGTH.
+    01 LK-AT-END            BINARY-CHAR UNSIGNED.
+
+PROCEDURE DIVISION USING LK-STATE LK-BUFFER LK-TAG-NAME LK-AT-END.
+    PERFORM UNTIL EXIT
+        CALL "NbtDecode-Peek" USING LK-STATE LK-BUFFER LK-AT-END TAG-NAME NAME-LEN
+        IF LK-AT-END > 0
+            GOBACK
+        END-IF
+        IF TAG-NAME(1:NAME-LEN) = LK-TAG-NAME
+            EXIT PERFORM
+        END-IF
+        CALL "NbtDecode-Skip" USING LK-STATE LK-BUFFER
+    END-PERFORM
+    MOVE 0 TO LK-AT-END
+    GOBACK.
+
+END PROGRAM NbtDecode-SkipUntilTag.
+
+*> --- NbtDecode-SkipRemainingTags ---
+*> A utility procedure to skip all remaining tags in a compound.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. NbtDecode-SkipRemainingTags.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 AT-END               BINARY-CHAR UNSIGNED.
+    01 TAG-NAME             PIC X(256).
+    01 NAME-LEN             BINARY-LONG UNSIGNED.
+LINKAGE SECTION.
+    COPY DD-NBT-DECODER REPLACING LEADING ==NBT-DECODER== BY ==LK==.
+    01 LK-BUFFER            PIC X ANY LENGTH.
+
+PROCEDURE DIVISION USING LK-STATE LK-BUFFER.
+    PERFORM UNTIL EXIT
+        CALL "NbtDecode-Peek" USING LK-STATE LK-BUFFER AT-END TAG-NAME NAME-LEN
+        IF AT-END > 0
+            GOBACK
+        END-IF
+        CALL "NbtDecode-Skip" USING LK-STATE LK-BUFFER
+    END-PERFORM
+    GOBACK.
+
+END PROGRAM NbtDecode-SkipRemainingTags.


### PR DESCRIPTION
This implements encoding/decoding of biome data when saving/loading to/from disk, as well as (crude) encoding of biome data in the chunk data packet. Finally, we can have more than just the plains biome.

For all encoding of biome data, Minecraft uses the same "paletted container" structure as for blocks, but the details are different enough that the code is not easily generalized (at least not in COBOL).

As a refactor, the SkipUntilTag and SkipRemainingTags helper programs are moved to nbt-decode.cob such that the chunk loading can be split into different parts that are all able to call the aforementioned helpers, which is not possible for sibling programs.