### PR TITLE
fix: Make game tick timing more precise

### DIFF
--- a/cpp/cobolcraft_util.cpp
+++ b/cpp/cobolcraft_util.cpp
@@ -18,6 +18,17 @@
 std::set<socket_t> CLIENT_SOCKETS;
 constexpr int SOCKET_CHUNK_LIMIT = 64000;
 
+EXTERN_DECL int SystemTimeMicros(long long *timestamp)
+{
+    if (!timestamp)
+    {
+        return ERRNO_PARAMS;
+    }
+    auto time = std::chrono::system_clock::now().time_since_epoch();
+    *timestamp = std::chrono::duration_cast<std::chrono::microseconds>(time).count();
+    return 0;
+}
+
 EXTERN_DECL int SystemTimeMillis(long long *timestamp)
 {
     if (!timestamp)

--- a/cpp/cobolcraft_util.h
+++ b/cpp/cobolcraft_util.h
@@ -3,6 +3,11 @@
 typedef int socket_t;
 
 /**
+ * Get the current system time in microseconds.
+ */
+EXTERN_DECL int SystemTimeMicros(long long *timestamp);
+
+/**
  * Get the current system time in milliseconds.
  */
 EXTERN_DECL int SystemTimeMillis(long long *timestamp);


### PR DESCRIPTION
Due to the way we perform game ticks, each tick is very slightly too long. The idea with this patch is to improve (1) the measurement precision and (2) the idle sleep duration, thereby reducing the average overshoot.

Tests show a 10x improvement, from 0.5ms down to 0.05ms on average.

Keepalive and autosave timers were updated accordingly.