### PR TITLE
fix: Fix "use_item_on" sequence number decoding

### DIFF
--- a/src/items/blocks.cob
+++ b/src/items/blocks.cob
@@ -38,9 +38,6 @@ PROCEDURE DIVISION USING LK-ITEM-NAME.
             GOBACK
         END-IF
 
-        *> TODO: When we GOBACK here, the client can sometimes become desynced. Send a packet with the current block
-        *>       state to fix this.
-
         *> Check for player collisison
         *> TODO make this more generic
         MOVE BLOCK-X TO PLACE-AABB-MIN-X

--- a/src/server.cob
+++ b/src/server.cob
@@ -1054,8 +1054,8 @@ HandlePlay.
             CALL "Decode-Float" USING CLIENT-RECEIVE-BUFFER PACKET-POSITION TEMP-CURSOR-Y
             CALL "Decode-Float" USING CLIENT-RECEIVE-BUFFER PACKET-POSITION TEMP-CURSOR-Z
 
-            *> TODO: "inside block" flag
-            ADD 1 TO PACKET-POSITION
+            *> TODO: "inside block" flag, "world border hit" flag
+            ADD 2 TO PACKET-POSITION
 
             *> sequence ID
             CALL "Decode-VarInt" USING CLIENT-RECEIVE-BUFFER PACKET-POSITION SEQUENCE-ID


### PR DESCRIPTION
There appears to be a new field "world border hit" before the sequence number. This was messing with our block acknowledge logic.