### PR TITLE
fix: Fix numeric move to group item

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,14 @@ COBC_OPTS = -free -DGCVERSION=$(GCVERSION) -I $(CPY_DIR) $(COB_FLAGS)
 COBC_OPTS += -O2 --debug -Wall -fnotrunc -fstatic-call
 
 ifeq ($(shell test $(GCVERSION) -ge 32; echo $$?),0)
+COBC_OPTS += -Werror=typing
 COB_MTFLAGS = -MF $(basename $@).d -MT $@
 GLOBALDEPS =
 # include dependency files for all existing object files
 -include $(OBJECTS:.o=.d)
 else
 # if dependency generation is not available: use global copy dependency
-COB_MTFLAGS = 
+COB_MTFLAGS =
 GLOBALDEPS = $(wildcard $(CPY_DIR)/*.cpy)
 endif
 

--- a/src/inventory/window-crafting.cob
+++ b/src/inventory/window-crafting.cob
@@ -81,9 +81,9 @@ PROCEDURE DIVISION.
         *> stash crafting input
         PERFORM VARYING SLOT FROM 1 BY 1 UNTIL SLOT > 9
             CALL "Inventory-StoreItem" USING PLAYER-INVENTORY(LK-PLAYER) PLAYER-WINDOW-SLOT(LK-PLAYER, SLOT + 1)
-            IF PLAYER-WINDOW-SLOT(LK-PLAYER, SLOT + 1) > 0
+            IF PLAYER-WINDOW-SLOT-COUNT(LK-PLAYER, SLOT + 1) > 0
                 *> TODO drop item
-                MOVE 0 TO PLAYER-WINDOW-SLOT(LK-PLAYER, SLOT + 1)
+                MOVE 0 TO PLAYER-WINDOW-SLOT-COUNT(LK-PLAYER, SLOT + 1)
             END-IF
         END-PERFORM
 


### PR DESCRIPTION
Also set GnuCOBOL to error on the "typing" warning that caught this issue, such that future compilations with similar errors fail. The "typing" warning is only available on GnuCOBOL >= 3.2.