### PR TITLE
chore: Reduce amount of codegen rebuilds

### DIFF
--- a/src/server.cob
+++ b/src/server.cob
@@ -45,7 +45,6 @@ WORKING-STORAGE SECTION.
     01 BYTE-COUNT                   BINARY-LONG UNSIGNED.
     01 BYTE-COUNT-EXPECTED          BINARY-LONG UNSIGNED.
     *> Temporary variables
-    01 TEMP-STR                     PIC X(255).
     01 TEMP-INT8                    BINARY-CHAR.
     01 TEMP-INT16                   BINARY-SHORT.
     01 TEMP-INT32                   BINARY-LONG.
@@ -173,11 +172,7 @@ LoadDatapack.
 
 LoadGenerated.
     DISPLAY "Loading generated data..."
-
-    *> Since this is generated code, we can't link statically.
-    *> TODO Try to link statically in the future.
-    MOVE "GC-BlocksLootTable" TO TEMP-STR
-    CALL TEMP-STR
+    CALL "GC-BlocksLootTable"
     .
 
 LoadPackets.


### PR DESCRIPTION
With some Makefile improvements, the codegen no longer rebuilds when any source file changes; it is only affected by things it actually needs.

This also unlocks static linking against the generated programs since the compilation order is now well-defined.