### PR TITLE
feat: Implement `random_chance` loot table condition

### DIFF
--- a/codegen/templates/blocks_loot_table/condition-random-chance.tpl.cob
+++ b/codegen/templates/blocks_loot_table/condition-random-chance.tpl.cob
@@ -1,0 +1,1 @@
+        CALL "LootTables-RandomChance" USING "$CHANCE$" COND

--- a/src/blocks/slab.cob
+++ b/src/blocks/slab.cob
@@ -50,6 +50,8 @@ PROCEDURE DIVISION.
         COPY DD-CALLBACK-BLOCK-DESTROY.
 
     PROCEDURE DIVISION USING LK-PLAYER LK-POSITION LK-FACE.
+        *> TODO: Remove this implementation in favor of loot tables
+
         CALL "World-GetBlock" USING LK-POSITION BLOCK-ID
         IF BLOCK-ID = AIR-BLOCK-STATE
             GOBACK

--- a/src/blocks/tall_grass.cob
+++ b/src/blocks/tall_grass.cob
@@ -5,7 +5,6 @@ PROGRAM-ID. RegisterBlock-TallGrass.
 DATA DIVISION.
 WORKING-STORAGE SECTION.
     01 HARDNESS                 FLOAT-SHORT                 VALUE 0.0.
-    01 DESTROY-PTR              PROGRAM-POINTER.
     01 FACE-PTR                 PROGRAM-POINTER.
     01 REPLACEABLE-PTR          PROGRAM-POINTER.
     01 BLOCK-COUNT              BINARY-LONG UNSIGNED.
@@ -17,7 +16,6 @@ WORKING-STORAGE SECTION.
     01 STATE-ID                 BINARY-LONG.
 
 PROCEDURE DIVISION.
-    SET DESTROY-PTR TO ENTRY "Callback-Destroy"
     SET FACE-PTR TO ENTRY "Callback-Face"
     SET REPLACEABLE-PTR TO ENTRY "Callback-Replaceable"
 
@@ -32,7 +30,6 @@ PROCEDURE DIVISION.
         IF BLOCK-TYPE = "minecraft:tall_grass" OR BLOCK-NAME = "minecraft:tall_grass"
             CALL "Blocks-Iterate-StateIds" USING BLOCK-INDEX BLOCK-MINIMUM-STATE-ID BLOCK-MAXIMUM-STATE-ID
             PERFORM VARYING STATE-ID FROM BLOCK-MINIMUM-STATE-ID BY 1 UNTIL STATE-ID > BLOCK-MAXIMUM-STATE-ID
-                CALL "SetCallback-BlockDestroy" USING STATE-ID DESTROY-PTR
                 CALL "SetCallback-BlockFace" USING STATE-ID FACE-PTR
                 CALL "SetCallback-BlockReplaceable" USING STATE-ID REPLACEABLE-PTR
             END-PERFORM
@@ -42,24 +39,6 @@ PROCEDURE DIVISION.
     END-PERFORM
 
     GOBACK.
-
-    *> --- Callback-Destroy ---
-    IDENTIFICATION DIVISION.
-    PROGRAM-ID. Callback-Destroy.
-
-    DATA DIVISION.
-    WORKING-STORAGE SECTION.
-        COPY DD-PLAYERS.
-        01 AIR-BLOCK-STATE          BINARY-LONG             VALUE 0.
-    LINKAGE SECTION.
-        COPY DD-CALLBACK-BLOCK-DESTROY.
-
-    PROCEDURE DIVISION USING LK-PLAYER LK-POSITION LK-FACE.
-        *> Tall grass doesn't drop an item.
-        CALL "World-SetBlock" USING PLAYER-CLIENT(LK-PLAYER) LK-POSITION AIR-BLOCK-STATE
-        GOBACK.
-
-    END PROGRAM Callback-Destroy.
 
     *> --- Callback-Face ---
     IDENTIFICATION DIVISION.

--- a/src/loot-tables.cob
+++ b/src/loot-tables.cob
@@ -1,3 +1,26 @@
+*> --- LootTables-RandomChance ---
+*> Evaluate a random chance condition.
+IDENTIFICATION DIVISION.
+PROGRAM-ID. LootTables-RandomChance.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 RANDOM-NUMBER            FLOAT-LONG.
+LINKAGE SECTION.
+    *> The chance, such as "0.125". Given as a string to avoid a working-storage item in each caller.
+    01 LK-CHANCE                PIC X ANY LENGTH.
+    *> The result; unchanged if the chance is met, set to 0 otherwise.
+    01 LK-COND                  BINARY-CHAR UNSIGNED.
+
+PROCEDURE DIVISION USING LK-CHANCE LK-COND.
+    *> TODO Use a better random number generator - dependent on the loot table's "random_sequence".
+    MOVE FUNCTION RANDOM TO RANDOM-NUMBER
+    IF RANDOM-NUMBER >= FUNCTION NUMVAL(LK-CHANCE)
+        MOVE 0 TO LK-COND
+    END-IF.
+
+END PROGRAM LootTables-RandomChance.
+
 *> --- BlocksLoot-Drop ---
 *> Helper function to be called by the BlocksLootTable generated code.
 *> Drops 1 piece of a named item at the given block position.


### PR DESCRIPTION
This allows tall grass, ferns etc. to sometimes drop seeds.

As a drive-by, this patch also completes the list of condition types with TODO placeholders, so there is a clear goal to work towards.