### PR TITLE
chore: Update to Ubuntu 25.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Ubuntu 24.04 has GnuCOBOL 3.1.2, while Ubuntu 24.10 has GnuCOBOL 3.2.0.
-        image-tag: ["24.04", "24.10"]
+        # Ubuntu 24.04 (LTS) has GnuCOBOL 3.1.2, while Ubuntu 25.04 (non-LTS) has GnuCOBOL 3.2.0.
+        image-tag: ["24.04", "25.04"]
         # Test on both x86 and ARM host architectures.
         os: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:oracular AS base
+FROM docker.io/library/ubuntu:plucky AS base
 
 WORKDIR /app
 


### PR DESCRIPTION
Ubuntu 25.04 (plucky) has the same GnuCOBOL version 3.2 as Ubuntu 24.10 (oracular), but both are non-LTS versions with support for only 9 months, and 24.10 support ends soon.