### PR TITLE
fix: keep the sign of negative JSON floats with a zero integer part

### DIFF
--- a/src/encoding/json-parse.cob
+++ b/src/encoding/json-parse.cob
@@ -389,6 +389,8 @@ WORKING-STORAGE SECTION.
     01 CHAR-ALPHA.
         02 CHARCODE         BINARY-CHAR UNSIGNED.
     01 MULTIPLIER       FLOAT-LONG.
+    01 IS-NEGATIVE      BINARY-CHAR UNSIGNED.
+    01 SIGN-OFFSET      BINARY-LONG UNSIGNED.
 LINKAGE SECTION.
     01 LK-INPUT         PIC X ANY LENGTH.
     01 LK-OFFSET        BINARY-LONG UNSIGNED.
@@ -397,6 +399,17 @@ LINKAGE SECTION.
 
 PROCEDURE DIVISION USING LK-INPUT LK-OFFSET LK-FLAG LK-VALUE.
     MOVE FUNCTION LENGTH(LK-INPUT) TO INPUT-LENGTH
+    *> Detect the sign up-front: a negative value with a zero integer part
+    *> (e.g. "-0.5") yields an integer of 0, which would otherwise drop the
+    *> sign when the fractional part is applied. Peek without consuming input;
+    *> JsonParse-Integer skips the same leading whitespace itself.
+    MOVE LK-OFFSET TO SIGN-OFFSET
+    COPY PROC-SKIP-WHITESPACE REPLACING ==STR== BY ==LK-INPUT== ==LEN== BY ==INPUT-LENGTH== ==IDX== BY ==SIGN-OFFSET==.
+    IF SIGN-OFFSET <= INPUT-LENGTH AND LK-INPUT(SIGN-OFFSET:1) = "-"
+        MOVE 1 TO IS-NEGATIVE
+    ELSE
+        MOVE 0 TO IS-NEGATIVE
+    END-IF
     *> start by reading the integer part
     CALL "JsonParse-Integer" USING LK-INPUT LK-OFFSET LK-FLAG INT-VALUE
     MOVE INT-VALUE TO LK-VALUE
@@ -406,7 +419,7 @@ PROCEDURE DIVISION USING LK-INPUT LK-OFFSET LK-FLAG LK-VALUE.
     END-IF
     ADD 1 TO LK-OFFSET
     *> read digits after the decimal point
-    IF LK-VALUE < 0
+    IF IS-NEGATIVE = 1
         MOVE -0.1 TO MULTIPLIER
     ELSE
         MOVE 0.1 TO MULTIPLIER

--- a/tests/encoding/json-parse.test.cob
+++ b/tests/encoding/json-parse.test.cob
@@ -496,6 +496,28 @@ PROCEDURE DIVISION.
         MOVE 1 TO FLAG
         CALL "JsonParse-Float" USING STR OFFSET FLAG RESULT
         COPY TEST-ASSERT REPLACING COND BY ==OFFSET = 11 AND FLAG = 0 AND RESULT = -1.23e-4==.
+    NegativeFractionOnly.
+        *> Regression: a negative value with a zero integer part must keep its sign.
+        COPY TEST-CASE REPLACING ==NAME== BY =="'  -0.5  '"==.
+        MOVE "  -0.5  " TO STR
+        MOVE 1 TO OFFSET
+        MOVE 1 TO FLAG
+        CALL "JsonParse-Float" USING STR OFFSET FLAG RESULT
+        COPY TEST-ASSERT REPLACING COND BY ==OFFSET = 7 AND FLAG = 0 AND RESULT = -0.5==.
+    NegativeFractionSmall.
+        COPY TEST-CASE REPLACING ==NAME== BY =="'  -0.0009  '"==.
+        MOVE "  -0.0009  " TO STR
+        MOVE 1 TO OFFSET
+        MOVE 1 TO FLAG
+        CALL "JsonParse-Float" USING STR OFFSET FLAG RESULT
+        COPY TEST-ASSERT REPLACING COND BY ==OFFSET = 10 AND FLAG = 0 AND RESULT = -0.0009==.
+    NegativeFractionExponent.
+        COPY TEST-CASE REPLACING ==NAME== BY =="'  -0.5e1  '"==.
+        MOVE "  -0.5e1  " TO STR
+        MOVE 1 TO OFFSET
+        MOVE 1 TO FLAG
+        CALL "JsonParse-Float" USING STR OFFSET FLAG RESULT
+        COPY TEST-ASSERT REPLACING COND BY ==OFFSET = 9 AND FLAG = 0 AND RESULT = -5.0==.
 
         GOBACK.
 


### PR DESCRIPTION
## Problem

`JsonParse-Float` loses the sign of any JSON number in the open interval `(-1, 0)`. The result comes back positive:

| input | before | after |
|---|---|---|
| `-0.5` | `+0.5` | `-0.5` |
| `-0.0009` | `+0.0009` | `-0.0009` |
| `-0.5e1` | `+5.0` | `-5.0` |
| `-1.5` | `-1.5` | `-1.5` (unaffected) |

## Root cause

The fractional multiplier's sign was taken from the parsed integer part:

```cobol
IF LK-VALUE < 0
    MOVE -0.1 TO MULTIPLIER
ELSE
    MOVE 0.1 TO MULTIPLIER
END-IF
```

For `-0.5` the integer part is `0`, and `JsonParse-Integer` returns `0` (it captures the `-` sign but multiplies it by a zero magnitude). So `LK-VALUE < 0` is false, the multiplier stays positive, and the sign is dropped. Values like `-1.5` work only because their integer magnitude is non-zero.

## Fix

Detect the `-` sign directly from the input before parsing, and use that flag to drive the fractional multiplier. The peek uses a separate offset and the same whitespace-skipping the integer parser already does, so it does not consume input or change the parse position.

## Tests

Added three regression cases to `Test-JsonParse-Float`: `-0.5`, `-0.0009`, and `-0.5e1`. Full suite: 315 run, 0 failed.

```
make test
...
Tests run: 315
Tests failed: 0
Tests skipped: 6
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
